### PR TITLE
Lint step in CI

### DIFF
--- a/.ci/test/lint.sh
+++ b/.ci/test/lint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -ex
+
+IGNORED_RULES=( build/include_subdir build/c++11 )
+SOURCE_DIRECTORIES=( native-filesystem )
+
+# Build `filter` argument for a list of ignored rules
+rule_filter=""
+for rule in "${IGNORED_RULES[@]}"
+do
+    rule_filter=-${rule},${rule_filter}
+done
+
+# Execute cpplint on all source directories
+for directory in "${SOURCE_DIRECTORIES[@]}"
+do
+    # TODO(LINKIWI): Don't force exit 0 after all lint errors have actually been fixed
+    cpplint \
+        --filter=${rule_filter} \
+        --recursive \
+        ${directory} || :
+done

--- a/.ci/test/prepare.sh
+++ b/.ci/test/prepare.sh
@@ -7,6 +7,10 @@ mkdir -p ~/.ssh
 openssl aes-256-cbc -K $encrypted_493c05fcd547_key -iv $encrypted_493c05fcd547_iv -in .ci/keys/deploy_id_rsa.enc -out ~/.ssh/id_rsa -d
 chmod 600 ~/.ssh/id_rsa
 
+# Install linter
+sudo pip install cpplint==1.3.0
+
+# Create build folders and compile
 mkdir build
 cd build
 cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
   - ./.ci/test/prepare.sh
 
 script:
+  - ./.ci/test/lint.sh
   - ./.ci/test/main.sh
 
 after_success:


### PR DESCRIPTION
Add `cpplint` to build as an additional step in the Travis script.

There are a list of default ignored rules (not compatible with the existing codebase) and source directories to lint in `lint.sh`.

As errors are being fixed, the lint step forces exit 0. This will be removed after the Improvements team finishes addressing all lint errors.

Fixes #17.