### PR TITLE
Exit with actual exit code for cpplint

### DIFF
--- a/.ci/test/lint.sh
+++ b/.ci/test/lint.sh
@@ -15,9 +15,8 @@ done
 # Execute cpplint on all source directories
 for directory in "${SOURCE_DIRECTORIES[@]}"
 do
-    # TODO(LINKIWI): Don't force exit 0 after all lint errors have actually been fixed
     cpplint \
         --filter=${rule_filter} \
         --recursive \
-        ${directory} || :
+        ${directory}
 done


### PR DESCRIPTION
Since we are explicitly whitelisting directories to lint, there's no good reason to force exit 0.

This will cause lint to exit with the real exit code. If there are lint errors in the specified directories, the build will correctly fail now.