### PR TITLE
Re-run flaky tests

### DIFF
--- a/.ci/test/main.sh
+++ b/.ci/test/main.sh
@@ -2,12 +2,25 @@
 
 set -ex
 
+run_flaky_test() {
+    for i in {1..3}
+    do
+        $1
+        if [ $? == 0 ] 
+	    then
+		    return 0
+	    fi
+    done
+
+    return 1
+}
+
 cd build/test
 ./ReplicationTest
 ./DeleteTest
-./NameNodeTest
+run_flaky_test ./NameNodeTest
 ./NativeFsTest
-./ZKDNClientTest
+run_flaky_test ./ZKDNClientTest
 ./ZKLockTest
-./ZKWrapperTest
+run_flaky_test ./ZKWrapperTest
 ./ReadWriteTest


### PR DESCRIPTION
This PR identifies existing "flaky" tests and runs them 3 times until success. In other words, if a flaky test passes once in 3 runs, then Travis considers this test a pass. We define a test as being "flaky" if it inconsistently passes and fails. This PR is mainly to reduce the need to rebuild Travis builds due to flaky tests.

This is a simple, quick fix for the issue of flaky tests in the repository. In the future, it might be worth it to invest more time and resources into pinpointing the exact causes for these tests' flakiness.