### PR TITLE
Properly shorten a std::string

### DIFF
--- a/utility/include/util.h
+++ b/utility/include/util.h
@@ -36,7 +36,7 @@ namespace util {
         }
         new_path += str2;
         if (new_path.at(new_path.length() - 1) == '/'){
-            new_path.at(new_path.length() - 1) = '\0';
+            new_path.pop_back();
         }
         return new_path;
     }

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -1122,7 +1122,7 @@ std::string ZkNnClient::ZookeeperPath(const std::string &hadoopPath) {
   }
   zkpath += hadoopPath;
   if (zkpath.at(zkpath.length() - 1) == '/') {
-    zkpath.at(zkpath.length() - 1) = '\0';
+    zkpath.pop_back();
   }
   return zkpath;
 }


### PR DESCRIPTION
The bug in *zk_nn_client.cc* turned up when I was debugging mkdir. I subsequently did a global search for `= '\0'`. It turns out there's one other spot where this naive assignment of null terminator is done. This seems to be a kind of bug not so specific to namenode, so here it goes.