### PR TITLE
added configurable node selection protocol

### DIFF
--- a/rice-namenode/source/main.cc
+++ b/rice-namenode/source/main.cc
@@ -30,6 +30,7 @@ using client_namenode_translator::ClientNamenodeTranslator;
  * command line.
  * @param verbosity A pointer in which to place the verbosity value entered at
  * the command line.
+ * @param node_policy A pointer in which to place the node_policy value entered at the command line.
  * @param backingStore A reference to set to the input backingStore.
  * @return 0 on success, -1 on any error.
  */

--- a/rice-namenode/source/main.cc
+++ b/rice-namenode/source/main.cc
@@ -47,7 +47,7 @@ static inline int parse_cmdline_options(
   // By setting opterr to 0, getopt does not print its own error messages.
   opterr = 0;
 
-  // We expect to find port setting, node policy setting, and/or verbosity setting
+  // We expect to find port, node policy, and/or verbosity settings
   while ((c = getopt(argc, argv, "v:p:n:")) != -1) {
     switch (c) {
       case 'v':*verbosity = atoi(optarg);
@@ -64,7 +64,8 @@ static inline int parse_cmdline_options(
         break;
       case 'n':*node_policy = optarg[0];
         if (*node_policy != MIN_XMITS || *node_policy != MAX_FREE_SPACE) {
-          LOG(ERROR) << "Node policy must be -x (minimum transmits) or -f (maximum free space)";
+          LOG(ERROR) << "Node policy must be -x (minimum transmits) or "
+                        "-f (maximum free space)";
           return -1;
         }
         break;

--- a/rice-namenode/source/main.cc
+++ b/rice-namenode/source/main.cc
@@ -37,7 +37,8 @@ static inline int parse_cmdline_options(
     int argc,
     char *argv[],
     int *port,
-    int *verbosity
+    int *verbosity,
+    char *node_policy
 ) {
   int c;
   char buf[64];
@@ -45,8 +46,8 @@ static inline int parse_cmdline_options(
   // By setting opterr to 0, getopt does not print its own error messages.
   opterr = 0;
 
-  // We expect to find port setting and/or verbosity setting
-  while ((c = getopt(argc, argv, "v:p:")) != -1) {
+  // We expect to find port setting, node policy setting, and/or verbosity setting
+  while ((c = getopt(argc, argv, "v:p:n:")) != -1) {
     switch (c) {
       case 'v':*verbosity = atoi(optarg);
         if (*verbosity < 0 || *verbosity > 9) {
@@ -60,6 +61,12 @@ static inline int parse_cmdline_options(
           return -1;
         }
         break;
+      case 'n':*node_policy = optarg[0];
+        if (*node_policy != MIN_XMITS || *node_policy != MAX_FREE_SPACE) {
+          LOG(ERROR) << "Node policy must be -x (minimum transmits) or -f (maximum free space)";
+          return -1;
+        }
+        break;
       case '?':
         switch (optopt) {
           case 'v':LOG(ERROR) << "Option -v requires an argument specifying a "
@@ -67,6 +74,9 @@ static inline int parse_cmdline_options(
             return -1;
           case 'p':LOG(ERROR) << "Option -p requires an argument specifying an "
                 "ipc port.";
+            return -1;
+          case 'n':LOG(ERROR) << "Option -n requires an argument specifying a "
+                 "node policy.";
             return -1;
           default:
             if (isprint(optopt)) {
@@ -102,8 +112,9 @@ int main(int argc, char *argv[]) {
   asio::io_service io_service;
   int port = 5351;
   int verbosity = 0;
+  char node_policy = MAX_FREE_SPACE;
 
-  parse_cmdline_options(argc, argv, &port, &verbosity);
+  parse_cmdline_options(argc, argv, &port, &verbosity, &node_policy);
 
   el::Loggers::setVerboseLevel(verbosity);
 
@@ -113,6 +124,7 @@ int main(int argc, char *argv[]) {
       "/testing");
   zkclient::ZkNnClient nncli(zk_shared);
   nncli.register_watches();
+  nncli.set_node_policy(node_policy);
 
   LOG(INFO) << "Namenode is starting";
   ClientNamenodeTranslator translator(port, &nncli);

--- a/rice-namenode/source/main.cc
+++ b/rice-namenode/source/main.cc
@@ -64,8 +64,8 @@ static inline int parse_cmdline_options(
         break;
       case 'n':*node_policy = optarg[0];
         if (*node_policy != MIN_XMITS || *node_policy != MAX_FREE_SPACE) {
-          LOG(ERROR) << "Node policy must be -x (minimum transmits) or "
-                        "-f (maximum free space)";
+          LOG(ERROR) << "Node policy, if any, must be -n x (minimum transmits)"
+                        " or -n f (maximum free space)";
           return -1;
         }
         break;

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -50,15 +50,15 @@ struct TargetDN {
   }
 
   bool operator<(const struct TargetDN &other) const {
-    //If storage policy is 'x' for xmits, choose the min xmits node
+    // If storage policy is 'x' for xmits, choose the min xmits node
     if (policy == MIN_XMITS) {
         if (num_xmits == other.num_xmits) {
             return free_bytes < other.free_bytes;
         }
         return num_xmits > other.num_xmits;
-    }
-    //default policy is choose the node with the most free space
-    else {
+
+    // Default policy is choose the node with the most free space
+    } else {
         if (free_bytes == other.free_bytes) {
             return num_xmits > other.num_xmits;
         }
@@ -101,7 +101,6 @@ using hadoop::hdfs::DatanodeInfoProto;
  */
 class ZkNnClient : public ZkClientCommon {
  public:
-
   char policy;
 
   explicit ZkNnClient(std::string zkIpAndAddress);

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -51,11 +51,19 @@ struct TargetDN {
 
   bool operator<(const struct TargetDN &other) const {
     //If storage policy is 'x' for xmits, choose the min xmits node
-    if (policy == MIN_XMITS)
+    if (policy == MIN_XMITS) {
+        if (num_xmits == other.num_xmits) {
+            return free_bytes < other.free_bytes;
+        }
         return num_xmits > other.num_xmits;
+    }
     //default policy is choose the node with the most free space
-    else
-        return free_bytes < free_bytes;
+    else {
+        if (free_bytes == other.free_bytes) {
+            return num_xmits > other.num_xmits;
+        }
+        return free_bytes < other.free_bytes;
+    }
   }
 };
 

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -266,7 +266,7 @@ void ZkNnClient::set_node_policy(char policy) {
   ZkNnClient::policy = policy;
 }
 
-char ZkNnClient::get_node_policy( ) {
+char ZkNnClient::get_node_policy() {
   return ZkNnClient::policy;
 }
 
@@ -1380,7 +1380,8 @@ bool ZkNnClient::find_datanode_for_block(std::vector<std::string> &datanodes,
                       << " with "
                       << stats.xmits
                       << " xmits";
-            targets.push(TargetDN(datanode, stats.free_bytes, stats.xmits, ZkNnClient::policy));
+            targets.push(TargetDN(datanode, stats.free_bytes, stats.xmits,
+                                  ZkNnClient::policy));
           }
         }
       }

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -262,6 +262,15 @@ bool ZkNnClient::get_block_size(const u_int64_t &block_id,
   return true;
 }
 
+void ZkNnClient::set_node_policy(char policy) {
+  ZkNnClient::policy = policy;
+}
+
+char ZkNnClient::get_node_policy( ) {
+  return ZkNnClient::policy;
+}
+
+
 // --------------------------- PROTOCOL CALLS -------------------------------
 
 void ZkNnClient::read_file_znode(FileZNode &znode_data,
@@ -1102,7 +1111,7 @@ bool ZkNnClient::sort_by_xmits(const std::vector<std::string> &unsorted_dn_ids,
     }
     DataNodePayload stats = DataNodePayload();
     memcpy(&stats, &stats_payload[0], sizeof(DataNodePayload));
-    targets.push(TargetDN(datanode, stats.free_bytes, stats.xmits));
+    targets.push(TargetDN(datanode, stats.free_bytes, stats.xmits, MIN_XMITS));
   }
 
   while (targets.size() > 0) {
@@ -1371,7 +1380,7 @@ bool ZkNnClient::find_datanode_for_block(std::vector<std::string> &datanodes,
                       << " with "
                       << stats.xmits
                       << " xmits";
-            targets.push(TargetDN(datanode, stats.free_bytes, stats.xmits));
+            targets.push(TargetDN(datanode, stats.free_bytes, stats.xmits, ZkNnClient::policy));
           }
         }
       }


### PR DESCRIPTION
This PR is for modifications to the node selection protocol for new blocks. 

RDFS 1.0 chooses the datanode with the fewest current in-progress transmits. This reduces initial write latency, and reduces the concurrent writes which, in Unix-based file systems, can cause lack of data locality, which in turn leads to excess seeks during reads. However, because RDFS datanode uses raw storage instead of the local Unix filesystem, it should mostly avoid this second case. 

In contrast, the node selection protocol described in the RDFS 2.0 spec is to pick the datanode with the most free space, thus spreading data load and making bandwidth load more likely be to evenly spread in the long-term.

Because each protocol has different advantages and disadvantages, depending on the specific scenario, extensive testing is required to determine which protocol is more efficient. Because the efficiency tradeoffs are so dependent on reducing bandwidth load, it is unclear if our same-machine development environment is even capable of testing these scenarios. Therefore, we decided to make the node selection policy configurable by command line, and leave the final decision about which to choose to a later date when more testing can be done. I am also adding a work item to do additional testing on these protocols.

To specify on the command line which protocol you would like to use, use "-n <policy>", where the available policies are "x" for minimum transmits and "f" for maximum free space. If no option is specified, maximum free space is the default policy.