### PR TITLE
Don't force-exit test script on nonzero command

### DIFF
--- a/.ci/test/main.sh
+++ b/.ci/test/main.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-run_flaky_test() {
+run_test() {
     for i in {1..3}
     do
         $1
@@ -12,16 +12,16 @@ run_flaky_test() {
 	    fi
     done
 
-    return 1
+    exit 1
 }
 
 cd build/test
-./ReplicationTest
-./DeleteTest
-run_flaky_test ./NameNodeTest
-./NativeFsTest
-run_flaky_test ./ZKDNClientTest
-./ZKLockTest
-run_flaky_test ./ZKWrapperTest
-./ReadWriteTest
-./StorageTest
+run_test ./ReadWriteTest
+run_test ./ReplicationTest
+run_test ./DeleteTest
+run_test ./NameNodeTest
+run_test ./NativeFsTest
+run_test ./StorageTest
+run_test ./ZKDNClientTest
+run_test ./ZKLockTest
+run_test ./ZKWrapperTest

--- a/.ci/test/main.sh
+++ b/.ci/test/main.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -x
 
 run_flaky_test() {
     for i in {1..3}


### PR DESCRIPTION
So it turns out #57 wasn't actually working because the test script itself was exiting on any failed command because of the `-e` flag.

Current behavior: unit test executable exits nonzero, `main.sh` exits immediately with same exit code.
With this PR: unit test executable exits nonzero, and logic allows the `for` loop to rerun the executable 3 times.