### PR TITLE
Removed default ephemeral argument for ZKWrapper::create...

### DIFF
--- a/test/namenode/DeletionTest.cc
+++ b/test/namenode/DeletionTest.cc
@@ -140,10 +140,10 @@ TEST_F(NamenodeTest, deleteBasicFileWithBlock) {
     memcpy(block_vec.data(), &block_id, sizeof(std::uint64_t));
     ASSERT_TRUE(zk->create("/fileSystem/delete_file/block-0000000000",
                            block_vec,
-                           error));
+                           error, false));
     ASSERT_TRUE(zk->create("/block_locations/1234",
                            ZKWrapper::EMPTY_VECTOR,
-                           error));
+                           error, false));
 
     // TODO(2016): create real block_locations for this block once we start
     // doing complete legitimately

--- a/test/namenode/NameNodeTest.cc
+++ b/test/namenode/NameNodeTest.cc
@@ -69,11 +69,13 @@ TEST_F(NamenodeTest, findDataNodes) {
   std::vector<uint8_t> stats_vec;
   stats_vec.resize(sizeof(zkclient::DataNodePayload));
   memcpy(&stats_vec[0], &data_node_payload, sizeof(zkclient::DataNodePayload));
-  ASSERT_TRUE(zk->create("/health/localhost:2181/stats", stats_vec, error, true));
+  ASSERT_TRUE(zk->create("/health/localhost:2181/stats",
+                         stats_vec, error, true));
 
   data_node_payload.xmits = 3;
   memcpy(&stats_vec[0], &data_node_payload, sizeof(zkclient::DataNodePayload));
-  ASSERT_TRUE(zk->create("/health/localhost:2182/stats", stats_vec, error, true));
+  ASSERT_TRUE(zk->create("/health/localhost:2182/stats",
+                         stats_vec, error, true));
 
   auto datanodes = std::vector<std::string>();
   u_int64_t block_id;

--- a/test/namenode/NameNodeTest.cc
+++ b/test/namenode/NameNodeTest.cc
@@ -33,14 +33,14 @@ TEST_F(NamenodeTest, checkNamespace) {
 
 TEST_F(NamenodeTest, findDataNodes) {
   int error;
-  zk->create("/health/localhost:2181", ZKWrapper::EMPTY_VECTOR, error);
+  zk->create("/health/localhost:2181", ZKWrapper::EMPTY_VECTOR, error, false);
   zk->create("/health/localhost:2181/heartbeat",
              ZKWrapper::EMPTY_VECTOR,
-             error);
-  zk->create("/health/localhost:2182", ZKWrapper::EMPTY_VECTOR, error);
+             error, true);
+  zk->create("/health/localhost:2182", ZKWrapper::EMPTY_VECTOR, error, false);
   zk->create("/health/localhost:2182/heartbeat",
              ZKWrapper::EMPTY_VECTOR,
-             error);
+             error, true);
 
   zkclient::DataNodePayload data_node_payload = zkclient::DataNodePayload();
   data_node_payload.ipcPort = 1;
@@ -52,11 +52,11 @@ TEST_F(NamenodeTest, findDataNodes) {
   std::vector<uint8_t> stats_vec;
   stats_vec.resize(sizeof(zkclient::DataNodePayload));
   memcpy(&stats_vec[0], &data_node_payload, sizeof(zkclient::DataNodePayload));
-  ASSERT_TRUE(zk->create("/health/localhost:2181/stats", stats_vec, error));
+  ASSERT_TRUE(zk->create("/health/localhost:2181/stats", stats_vec, error, true));
 
   data_node_payload.xmits = 3;
   memcpy(&stats_vec[0], &data_node_payload, sizeof(zkclient::DataNodePayload));
-  ASSERT_TRUE(zk->create("/health/localhost:2182/stats", stats_vec, error));
+  ASSERT_TRUE(zk->create("/health/localhost:2182/stats", stats_vec, error, true));
 
   auto datanodes = std::vector<std::string>();
   u_int64_t block_id;
@@ -68,7 +68,7 @@ TEST_F(NamenodeTest, findDataNodes) {
   memcpy(&data_vect[0], &block_data, sizeof(block_data));
   ASSERT_TRUE(zk->create("/block_locations/" + std::to_string(block_id),
                          data_vect,
-                         error));
+                         error, false));
 
   LOG(INFO) << "Finding dn's for block " << block_id;
   int rep_factor = 1;
@@ -106,7 +106,7 @@ TEST_F(NamenodeTest, basicCheckAcks) {
 
   zk->create("/work_queues/wait_for_acks/block_uuid_1/dn-id-1",
              ZKWrapper::EMPTY_VECTOR,
-             error);
+             error, false);
   ASSERT_EQ(0, error);
 
   // Only one DN acknowledged, but not timed out, so should succeed
@@ -114,14 +114,14 @@ TEST_F(NamenodeTest, basicCheckAcks) {
 
   zk->create("/work_queues/wait_for_acks/block_uuid_1/dn-id-2",
              ZKWrapper::EMPTY_VECTOR,
-             error);
+             error, false);
   ASSERT_EQ(0, error);
   // Only two DNs acknowledged, but not timed out, so should succeed
   ASSERT_EQ(true, client->check_acks());
 
   zk->create("/work_queues/wait_for_acks/block_uuid_1/dn-id-3",
              ZKWrapper::EMPTY_VECTOR,
-             error);
+             error, false);
   ASSERT_EQ(0, error);
   // All three DNs acknowledged, so should succeed
   ASSERT_EQ(true, client->check_acks());
@@ -143,15 +143,15 @@ TEST_F(NamenodeTest, previousBlockComplete) {
   ASSERT_EQ(true, client->previousBlockComplete(block_id));
   util::generate_uuid(block_id);
   /* mock the directory */
-  zk->create("/block_locations", ZKWrapper::EMPTY_VECTOR, error);
+  zk->create("/block_locations", ZKWrapper::EMPTY_VECTOR, error, false);
   zk->create("/block_locations/" + std::to_string(block_id),
              ZKWrapper::EMPTY_VECTOR,
-             error);
+             error, false);
   ASSERT_EQ(false, client->previousBlockComplete(block_id));
   /* mock the child directory */
   zk->create("/block_locations/" + std::to_string(block_id) + "/child1",
              ZKWrapper::EMPTY_VECTOR,
-             error);
+             error, false);
   ASSERT_EQ(true, client->previousBlockComplete(block_id));
 }
 

--- a/test/namenode/NameNodeTest.cc
+++ b/test/namenode/NameNodeTest.cc
@@ -52,11 +52,13 @@ TEST_F(NamenodeTest, findDataNodes) {
   std::vector<uint8_t> stats_vec;
   stats_vec.resize(sizeof(zkclient::DataNodePayload));
   memcpy(&stats_vec[0], &data_node_payload, sizeof(zkclient::DataNodePayload));
-  ASSERT_TRUE(zk->create("/health/localhost:2181/stats", stats_vec, error, true));
+  ASSERT_TRUE(zk->create("/health/localhost:2181/stats",
+                         stats_vec, error, true));
 
   data_node_payload.xmits = 3;
   memcpy(&stats_vec[0], &data_node_payload, sizeof(zkclient::DataNodePayload));
-  ASSERT_TRUE(zk->create("/health/localhost:2182/stats", stats_vec, error, true));
+  ASSERT_TRUE(zk->create("/health/localhost:2182/stats",
+                         stats_vec, error, true));
 
   auto datanodes = std::vector<std::string>();
   u_int64_t block_id;

--- a/test/zkwrapper/ZKWrapperTest.cc
+++ b/test/zkwrapper/ZKWrapperTest.cc
@@ -106,7 +106,8 @@ TEST_F(ZKWrapperTest, exists) {
   int error = 0;
   bool exist = false;
 
-  bool result = zk->create("/testcreate", ZKWrapper::EMPTY_VECTOR, error, false);
+  bool result = zk->create("/testcreate", ZKWrapper::EMPTY_VECTOR,
+                           error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -264,7 +265,8 @@ TEST_F(ZKWrapperTest, set) {
 TEST_F(ZKWrapperTest, delete_node) {
   int error = 0;
 
-  bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR, error, false);
+  bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR,
+                           error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 

--- a/test/zkwrapper/ZKWrapperTest.cc
+++ b/test/zkwrapper/ZKWrapperTest.cc
@@ -265,8 +265,12 @@ TEST_F(ZKWrapperTest, set) {
 TEST_F(ZKWrapperTest, delete_node) {
   int error = 0;
 
+<<<<<<< HEAD
   bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR,
                            error, false);
+=======
+  bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR, error, false);
+>>>>>>> Removed default ephemeral argument for ZKWrapper::create as described in #73. It appears that heartbeat znodes are being handled correctly
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 

--- a/test/zkwrapper/ZKWrapperTest.cc
+++ b/test/zkwrapper/ZKWrapperTest.cc
@@ -106,7 +106,7 @@ TEST_F(ZKWrapperTest, exists) {
   int error = 0;
   bool exist = false;
 
-  bool result = zk->create("/testcreate", ZKWrapper::EMPTY_VECTOR, error);
+  bool result = zk->create("/testcreate", ZKWrapper::EMPTY_VECTOR, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -131,7 +131,7 @@ TEST_F(ZKWrapperTest, wexists) {
   ASSERT_EQ(false, exist);
   ASSERT_EQ("ZNONODE", zk->translate_error(error));
 
-  result = zk->create("/testwexists", ZKWrapper::EMPTY_VECTOR, error);
+  result = zk->create("/testwexists", ZKWrapper::EMPTY_VECTOR, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -158,7 +158,7 @@ TEST_F(ZKWrapperTest, wget_children) {
   bool result = zk->create(
       "/testwgetchildren1",
       ZKWrapper::EMPTY_VECTOR,
-      error);
+      error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -176,7 +176,7 @@ TEST_F(ZKWrapperTest, wget_children) {
   result = zk->create(
       "/testwgetchildren1/test",
       ZKWrapper::EMPTY_VECTOR,
-      error);
+      error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -191,7 +191,7 @@ TEST_F(ZKWrapperTest, wget_children) {
 }
 TEST_F(ZKWrapperTest, get) {
   int error = 0;
-  bool result = zk->create("/testget", ZKWrapper::EMPTY_VECTOR, error);
+  bool result = zk->create("/testget", ZKWrapper::EMPTY_VECTOR, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -203,7 +203,7 @@ TEST_F(ZKWrapperTest, get) {
 
   auto data_1 = ZKWrapper::get_byte_vector("hello");
 
-  result = zk->create("/testget_withdata", data_1, error);
+  result = zk->create("/testget_withdata", data_1, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -216,7 +216,7 @@ TEST_F(ZKWrapperTest, get) {
 
 TEST_F(ZKWrapperTest, wget) {
   int error = 0;
-  bool result = zk->create("/testwget1", ZKWrapper::EMPTY_VECTOR, error);
+  bool result = zk->create("/testwget1", ZKWrapper::EMPTY_VECTOR, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -246,7 +246,7 @@ TEST_F(ZKWrapperTest, set) {
   int error = 0;
   auto data = ZKWrapper::get_byte_vector("hello");
 
-  bool result = zk->create("/testget1", ZKWrapper::EMPTY_VECTOR, error);
+  bool result = zk->create("/testget1", ZKWrapper::EMPTY_VECTOR, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -264,7 +264,7 @@ TEST_F(ZKWrapperTest, set) {
 TEST_F(ZKWrapperTest, delete_node) {
   int error = 0;
 
-  bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR, error);
+  bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
@@ -280,10 +280,10 @@ TEST_F(ZKWrapperTest, delete_node) {
 TEST_F(ZKWrapperTest, RecursiveDelete) {
   int error_code;
 
-  zk->create("/child1", ZKWrapper::EMPTY_VECTOR, error_code);
-  zk->create("/child2", ZKWrapper::EMPTY_VECTOR, error_code);
-  zk->create("/child1/child2", ZKWrapper::EMPTY_VECTOR, error_code);
-  zk->create("/child1/child3", ZKWrapper::EMPTY_VECTOR, error_code);
+  zk->create("/child1", ZKWrapper::EMPTY_VECTOR, error_code, false);
+  zk->create("/child2", ZKWrapper::EMPTY_VECTOR, error_code, false);
+  zk->create("/child1/child2", ZKWrapper::EMPTY_VECTOR, error_code, false);
+  zk->create("/child1/child3", ZKWrapper::EMPTY_VECTOR, error_code, false);
 
   ASSERT_TRUE(zk->recursive_delete("/child1", error_code));
 

--- a/test/zkwrapper/ZKWrapperTest.cc
+++ b/test/zkwrapper/ZKWrapperTest.cc
@@ -265,12 +265,8 @@ TEST_F(ZKWrapperTest, set) {
 TEST_F(ZKWrapperTest, delete_node) {
   int error = 0;
 
-<<<<<<< HEAD
   bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR,
                            error, false);
-=======
-  bool result = zk->create("/testcreate2", ZKWrapper::EMPTY_VECTOR, error, false);
->>>>>>> Removed default ephemeral argument for ZKWrapper::create as described in #73. It appears that heartbeat znodes are being handled correctly
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
 

--- a/test/zookeeper/zk_dn_client_test.cc
+++ b/test/zookeeper/zk_dn_client_test.cc
@@ -62,7 +62,7 @@ TEST_F(ZKDNClientTest, CanReadBlockSize) {
 
   std::string path = "/block_locations/" + std::to_string(block_id);
   std::vector<std::uint8_t> data(sizeof(BlockZNode));
-  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code);
+  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code, false);
 
   client->blockReceived(block_id, block_size);
 
@@ -79,7 +79,7 @@ TEST_F(ZKDNClientTest, CanDeleteBlock) {
   std::string path = "/block_locations/" + std::to_string(block_id);
   std::vector<std::uint8_t> data(sizeof(BlockZNode));
 
-  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code);
+  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code, false);
 
   client->blockReceived(block_id, block_size);
   ASSERT_TRUE(zk->get(path + "/" + dn_id, data, error_code));

--- a/test/zookeeper/zk_dn_client_test.cc
+++ b/test/zookeeper/zk_dn_client_test.cc
@@ -65,7 +65,7 @@ TEST_F(ZKDNClientTest, CanReadBlockSize) {
 
   std::string path = "/block_locations/" + std::to_string(block_id);
   std::vector<std::uint8_t> data(sizeof(BlockZNode));
-  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code);
+  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code, false);
 
   client->blockReceived(block_id, block_size);
 
@@ -82,7 +82,7 @@ TEST_F(ZKDNClientTest, CanDeleteBlock) {
   std::string path = "/block_locations/" + std::to_string(block_id);
   std::vector<std::uint8_t> data(sizeof(BlockZNode));
 
-  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code);
+  zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code, false);
 
   client->blockReceived(block_id, block_size);
   ASSERT_TRUE(zk->get(path + "/" + dn_id, data, error_code));

--- a/zkwrapper/include/zkwrapper.h
+++ b/zkwrapper/include/zkwrapper.h
@@ -94,7 +94,7 @@ class ZKWrapper {
   bool create(const std::string &path,
               const std::vector<std::uint8_t> &data,
               int &error_code,
-              bool ephemeral = false,
+              bool ephemeral,
               bool sync = true) const;
 
   bool create_ephemeral(const std::string &path,

--- a/zookeeper/source/zk_client_common.cc
+++ b/zookeeper/source/zk_client_common.cc
@@ -47,14 +47,14 @@ void ZkClientCommon::init() {
   // TODO(2016): Add in error handling for failures
   if (zk->exists("/health", exists, error_code)) {
     if (!exists) {
-      zk->create("/health", vec, error_code);
+      zk->create("/health", vec, error_code, false);
     }
   } else {
     // TODO(2016): Handle error
   }
   if (zk->exists("/fileSystem", exists, error_code)) {
     if (!exists) {
-      zk->create("/fileSystem", vec, error_code);
+      zk->create("/fileSystem", vec, error_code, false);
     } else {
     }
   } else {
@@ -85,7 +85,7 @@ void ZkClientCommon::init() {
   }
   if (zk->exists("/block_locations", exists, error_code)) {
     if (!exists) {
-      zk->create("/block_locations", vec, error_code);
+      zk->create("/block_locations", vec, error_code, false);
     }
   } else {
     // TODO(2016): Handle error

--- a/zookeeper/source/zk_dn_client.cc
+++ b/zookeeper/source/zk_dn_client.cc
@@ -165,7 +165,7 @@ void ZkClientDn::registerDataNode(const std::string &ip,
   }
 
   if (!zk->create(HEALTH_BACKSLASH + id,
-                  ZKWrapper::EMPTY_VECTOR, error_code)) {
+                  ZKWrapper::EMPTY_VECTOR, error_code, false)) {
     LOG(ERROR) << "Failed creating /health/<data_node_id> "
                << error_code;
   }
@@ -183,13 +183,13 @@ void ZkClientDn::registerDataNode(const std::string &ip,
   data.resize(sizeof(DataNodePayload));
   memcpy(&data[0], &data_node_payload, sizeof(DataNodePayload));
 
-  if (!zk->create(HEALTH_BACKSLASH + id + STATS, data, error_code, false)) {
+  if (!zk->create(HEALTH_BACKSLASH + id + STATS, data, error_code, true)) {
     LOG(ERROR) << "Failed creating /health/<data_node_id>/stats "
                << error_code;
   }
 
   if (!zk->create(HEALTH_BACKSLASH + id + BLOCKS,
-                  ZKWrapper::EMPTY_VECTOR, error_code)) {
+                  ZKWrapper::EMPTY_VECTOR, error_code, false)) {
     LOG(ERROR) << "Failed creating /health/<data_node_id>/blocks "
                << error_code;
   }
@@ -231,7 +231,7 @@ bool ZkClientDn::push_dn_on_repq(std::string dn_name, uint64_t blockid) {
   std::vector<std::shared_ptr<ZooOp>> ops;
   std::vector<zoo_op_result> results;
   auto work_item = util::concat_path(queue_path, std::to_string(blockid));
-  if (!zk->create(work_item, ZKWrapper::EMPTY_VECTOR, error)) {
+  if (!zk->create(work_item, ZKWrapper::EMPTY_VECTOR, error, false)) {
     LOG(ERROR) << "Failed to create replication commands for pipelining!";
     return false;
   }

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -133,7 +133,7 @@ void ZkNnClient::watcher_health(zhandle_t *zzh, int type, int state,
  */
 void ZkNnClient::watcher_health_child(zhandle_t *zzh, int type, int state,
                                       const char *raw_path, void *watcherCtx) {
-  LOG(INFO) << "Health child water triggered on " << raw_path;
+  LOG(INFO) << "Health child watcher triggered on " << raw_path;
 
   ZkNnClient *cli = reinterpret_cast<ZkNnClient *>(watcherCtx);
   auto zk = cli->zk;
@@ -513,7 +513,7 @@ bool ZkNnClient::create_file_znode(const std::string &path,
     std::vector<std::uint8_t> data(sizeof(*znode_data));
     file_znode_struct_to_vec(znode_data, data);
     // crate the node in zookeeper
-    if (!zk->create(ZookeeperPath(path), data, error_code)) {
+    if (!zk->create(ZookeeperPath(path), data, error_code, false)) {
       LOG(ERROR) << "Create failed with error code " << error_code;
       return false;
       // TODO(2016): handle error
@@ -1741,6 +1741,8 @@ bool ZkNnClient::replicate_blocks(const std::vector<std::string> &to_replicate,
     LOG(ERROR) << "Failed to execute multiop for replicate_blocks";
     return false;
   }
+
+  return true;
 }
 
 bool ZkNnClient::find_all_datanodes_with_block(

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -133,7 +133,7 @@ void ZkNnClient::watcher_health(zhandle_t *zzh, int type, int state,
  */
 void ZkNnClient::watcher_health_child(zhandle_t *zzh, int type, int state,
                                       const char *raw_path, void *watcherCtx) {
-  LOG(INFO) << "Health child water triggered on " << raw_path;
+  LOG(INFO) << "Health child watcher triggered on " << raw_path;
 
   ZkNnClient *cli = reinterpret_cast<ZkNnClient *>(watcherCtx);
   auto zk = cli->zk;
@@ -513,7 +513,7 @@ int ZkNnClient::create_file_znode(const std::string &path,
     std::vector<std::uint8_t> data(sizeof(*znode_data));
     file_znode_struct_to_vec(znode_data, data);
     // crate the node in zookeeper
-    if (!zk->create(ZookeeperPath(path), data, error_code)) {
+    if (!zk->create(ZookeeperPath(path), data, error_code, false)) {
       LOG(ERROR) << "Create failed" << error_code;
       return 0;
       // TODO(2016): handle error
@@ -1720,6 +1720,8 @@ bool ZkNnClient::replicate_blocks(const std::vector<std::string> &to_replicate,
     LOG(ERROR) << "Failed to execute multiop for replicate_blocks";
     return false;
   }
+
+  return true;
 }
 
 bool ZkNnClient::find_all_datanodes_with_block(

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -515,7 +515,7 @@ bool ZkNnClient::create_file_znode(const std::string &path,
     file_znode_struct_to_vec(znode_data, data);
     // crate the node in zookeeper
     if (!zk->create(ZookeeperPath(path), data, error_code, false)) {
-      LOG(ERROR) << "Create failed" << error_code;
+      LOG(ERROR) << "Create failed with error code " << error_code;
       return false;
       // TODO(2016): handle error
     }

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -133,7 +133,7 @@ void ZkNnClient::watcher_health(zhandle_t *zzh, int type, int state,
  */
 void ZkNnClient::watcher_health_child(zhandle_t *zzh, int type, int state,
                                       const char *raw_path, void *watcherCtx) {
-  LOG(INFO) << "Health child water triggered on " << raw_path;
+  LOG(INFO) << "Health child watcher triggered on " << raw_path;
 
   ZkNnClient *cli = reinterpret_cast<ZkNnClient *>(watcherCtx);
   auto zk = cli->zk;
@@ -514,8 +514,8 @@ bool ZkNnClient::create_file_znode(const std::string &path,
     std::vector<std::uint8_t> data(sizeof(*znode_data));
     file_znode_struct_to_vec(znode_data, data);
     // crate the node in zookeeper
-    if (!zk->create(ZookeeperPath(path), data, error_code)) {
-      LOG(ERROR) << "Create failed with error code " << error_code;
+    if (!zk->create(ZookeeperPath(path), data, error_code, false)) {
+      LOG(ERROR) << "Create failed" << error_code;
       return false;
       // TODO(2016): handle error
     }
@@ -1742,6 +1742,8 @@ bool ZkNnClient::replicate_blocks(const std::vector<std::string> &to_replicate,
     LOG(ERROR) << "Failed to execute multiop for replicate_blocks";
     return false;
   }
+
+  return true;
 }
 
 bool ZkNnClient::find_all_datanodes_with_block(


### PR DESCRIPTION
…in order to resolve #73. It appears that heartbeat znodes are being handled correctly, but this PR makes the `ZKWrapper::create` semantics explicit to avoid confusion or accidental non-ephemeral status of ZNodes that should be ephemeral. My examination of ReplicationTest suggests that no large-scale mistakes relating to this lack of clarity exist currently, but this change should help to prevent any future issues.

Changes made by this PR largely consist of removing the default `ephemeral = false` parameter to ZKWrapper::create, then refactoring all method calls that depended on the ellision of this parameter. 

I also fixed the fall-through case in `ZkNnClient::replicate_blocks`, which was incorrectly returning false on correct execution and generating spurious error messages.