### PR TITLE
Rice Hadoop mirror

### DIFF
--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-HADOOP_MIRROR=http://www.gtlib.gatech.edu/pub/apache/hadoop/common/hadoop-2.8.1/hadoop-2.8.1.tar.gz
+HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 
 cd $HOME
 wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR


### PR DESCRIPTION
This fixes download errors in the build install step.

Want to get this merged in as soon as possible to unblock devs, will look into options for faster mirrors soon.