### PR TITLE
Travis build cache for protobuf, hadoop

### DIFF
--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -5,10 +5,11 @@ set -ex
 HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 
 cd $HOME
-if [ ! -f /tmp/cache/hadoop.tar.gz ]; then
-    wget --quiet -O /tmp/cache/hadoop.tar.gz $HADOOP_MIRROR
+if [ ! -d /tmp/cache/hadoop ]; then
+    wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
+    tar -xf hadoop.tar.gz -C /tmp
+    mv /tmp/hadoop-2.8.1 /tmp/cache/hadoop
 fi
-tar -xf /tmp/cache/hadoop.tar.gz
-mv hadoop-2.8.1 hadoop
+mv /tmp/cache/hadoop hadoop
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml
 cp $TRAVIS_BUILD_DIR/config/core-site.xml hadoop/etc/hadoop/core-site.xml

--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -5,8 +5,10 @@ set -ex
 HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 
 cd $HOME
-wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
-tar -xf hadoop.tar.gz
+if [ ! -f /tmp/cache/protobuf.zip ]; then
+    wget --quiet -O /tmp/cache/hadoop.tar.gz $HADOOP_MIRROR
+fi
+tar -xf /tmp/cache/hadoop.tar.gz
 rm hadoop.tar.gz
 mv hadoop-2.8.1 hadoop
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml

--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -10,6 +10,6 @@ if [ ! -d /tmp/cache/hadoop ]; then
     tar -xf hadoop.tar.gz -C /tmp
     mv /tmp/hadoop-2.8.1 /tmp/cache/hadoop
 fi
-mv /tmp/cache/hadoop hadoop
+ln -s /tmp/cache/hadoop hadoop
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml
 cp $TRAVIS_BUILD_DIR/config/core-site.xml hadoop/etc/hadoop/core-site.xml

--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -5,11 +5,10 @@ set -ex
 HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 
 cd $HOME
-if [ ! -f /tmp/cache/protobuf.zip ]; then
+if [ ! -f /tmp/cache/hadoop.tar.gz ]; then
     wget --quiet -O /tmp/cache/hadoop.tar.gz $HADOOP_MIRROR
 fi
 tar -xf /tmp/cache/hadoop.tar.gz
-rm hadoop.tar.gz
 mv hadoop-2.8.1 hadoop
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml
 cp $TRAVIS_BUILD_DIR/config/core-site.xml hadoop/etc/hadoop/core-site.xml

--- a/.ci/install/protobuf.sh
+++ b/.ci/install/protobuf.sh
@@ -5,8 +5,10 @@ set -ex
 PROTOBUF_CACHE=http://kevinlin.web.rice.edu/static/protobuf.zip
 
 cd $HOME
-wget --quiet -O protobuf.zip $PROTOBUF_CACHE
-unzip protobuf.zip > /dev/null
+if [ ! -f /tmp/cache/protobuf.zip ]; then
+    wget --quiet -O /tmp/cache/protobuf.zip $PROTOBUF_CACHE
+fi
+unzip /tmp/cache/protobuf.zip > /dev/null
 cd protobuf-3.0.0
 sudo make install > /dev/null
 sudo ldconfig

--- a/.ci/install/protobuf.sh
+++ b/.ci/install/protobuf.sh
@@ -5,10 +5,12 @@ set -ex
 PROTOBUF_CACHE=http://kevinlin.web.rice.edu/static/protobuf.zip
 
 cd $HOME
-if [ ! -f /tmp/cache/protobuf.zip ]; then
-    wget --quiet -O /tmp/cache/protobuf.zip $PROTOBUF_CACHE
+if [ ! -d /tmp/cache/protobuf ]; then
+    wget --quiet -O protobuf.zip $PROTOBUF_CACHE
+    unzip protobuf.zip > /dev/null
+    mv protobuf-3.0.0 /tmp/cache/protobuf
 fi
-unzip /tmp/cache/protobuf.zip > /dev/null
+mv /tmp/cache/protobuf protobuf-3.0.0
 cd protobuf-3.0.0
 sudo make install > /dev/null
 sudo ldconfig

--- a/.ci/install/protobuf.sh
+++ b/.ci/install/protobuf.sh
@@ -10,7 +10,7 @@ if [ ! -d /tmp/cache/protobuf ]; then
     unzip protobuf.zip > /dev/null
     mv protobuf-3.0.0 /tmp/cache/protobuf
 fi
-mv /tmp/cache/protobuf protobuf-3.0.0
+ln -s /tmp/cache/protobuf protobuf-3.0.0
 cd protobuf-3.0.0
 sudo make install > /dev/null
 sudo ldconfig

--- a/.ci/install/zookeeper.sh
+++ b/.ci/install/zookeeper.sh
@@ -5,9 +5,10 @@ set -ex
 ZOOKEEPER_MIRROR=http://mirror.reverse.net/pub/apache/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz
 
 cd $HOME
-wget --quiet -O zookeeper.tar.gz $ZOOKEEPER_MIRROR
-tar -xf zookeeper.tar.gz
-rm zookeeper.tar.gz
+if [ ! -f /tmp/cache/zookeeper.tar.gz ]; then
+    wget --quiet -O /tmp/cache/zookeeper.tar.gz $ZOOKEEPER_MIRROR
+fi
+tar -xf /tmp/cache/zookeeper.tar.gz
 mv zookeeper-3.4.9 zookeeper
 cat > zookeeper/conf/zoo.cfg <<EOF
 tickTime=2000
@@ -19,7 +20,7 @@ EOF
 cd zookeeper
 ant compile_jute
 cd src/c
-autoreconf -if
+autoreconf -if > /dev/null
 ./configure
 sudo make > /dev/null
 sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ env:
     - CLASSPATH=$HOME/hadoop/share/hadoop/hdfs/*:$HOME/hadoop/share/hadoop/common/*
 
 before_install:
-  - mkdir -p /tmp/cache
   - ./.ci/install/protobuf.sh
   - ./.ci/install/hadoop.sh
   - ./.ci/install/zookeeper.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - CLASSPATH=$HOME/hadoop/share/hadoop/hdfs/*:$HOME/hadoop/share/hadoop/common/*
 
 before_install:
+  - mkdir -p /tmp/cache
   - ./.ci/install/protobuf.sh
   - ./.ci/install/hadoop.sh
   - ./.ci/install/zookeeper.sh
@@ -49,3 +50,7 @@ script:
 
 after_success:
   - ./.ci/publish/docs.sh
+
+cache:
+  directories:
+    - /tmp/cache


### PR DESCRIPTION
Use Travis to cache the extracted contents of the protobuf and hadoop dependencies.

In most cases, builds will have a warm cache. These dependencies will never change, so in theory, this PR is the only one that will ever start with a cold cache.

This also reduces the need to pull the tarballs from CLEAR on every build, which is bandwidth-limited and slow.

Compared to ad8cb0a6b6075691f82274f2c707bc09053f16f9, this reduces build times by ~300s.
Compared to 38b71d7a53baa042bac76382d6ec29539666a101, this reduces build times by ~150s.

Closes #94.