### PR TITLE
remove all the hard coded assumptions that block metadata locations

### DIFF
--- a/zookeeper/include/zk_client_common.h
+++ b/zookeeper/include/zk_client_common.h
@@ -34,6 +34,7 @@ class ZkClientCommon {
   static const char WAIT_FOR_ACK_BACKSLASH[];
   static const char REPLICATE_BACKSLASH[];
   static const char BLOCK_LOCATIONS[];
+  static const char BLOCK_GROUP_LOCATIONS[];
   static const char BLOCKS[];
 
  private:

--- a/zookeeper/include/zk_client_common.h
+++ b/zookeeper/include/zk_client_common.h
@@ -17,6 +17,24 @@ class ZkClientCommon {
   explicit ZkClientCommon(std::shared_ptr<ZKWrapper> zk);
 
   void init();
+
+
+  /**
+   * true if the highest bit is set to 1. false otherwise.
+   * @param block_id the id of a block (or a block group)
+   * @return true or false.
+   */
+  bool is_ec_block(u_int64_t block_id);
+
+  /**
+   * Given a block or block group id, returns the path to the corresponding metadata.
+   * For a non EC block, it is BLOCK_LOCATIONS + ID
+   * For an EC block, it is BLOCK_GROUP_LOCATIONS + ID
+   * @param block_or_block_group_id the id of a block or a block group.
+   * @return the path to the corresponding metadata.
+   */
+  std::string get_block_metadata_path(u_int64_t block_or_block_group_id);
+
   std::shared_ptr<ZKWrapper> zk;
 
   // constants used by the clients

--- a/zookeeper/include/zk_dn_client.h
+++ b/zookeeper/include/zk_dn_client.h
@@ -149,7 +149,7 @@ class ZkClientDn : public ZkClientCommon {
   /**
    * Find one datanode that has the block_uuid
    */
-  bool find_datanode_with_block(const std::string &block_uuid_str,
+  bool find_datanode_with_block(uint64_t &block_uuid,
                                 std::string &datanode,
                                 int &error_code);
 

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -31,7 +31,7 @@ typedef enum class FileStatus : int {
  */
 typedef struct {
   uint32_t replication;  // the block replication factor.
-  std::string ecPolicyName;  // the specified EC policy name.
+//  std::string ecPolicyName;  // the specified EC policy name.
   uint64_t blocksize;
   // 1 for under construction, 0 for complete
   zkclient::FileStatus under_construction;

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -312,7 +312,7 @@ class ZkNnClient : public ZkClientCommon {
                                bool newBlock,
                                uint64_t blocksize);
 
-  bool find_all_datanodes_with_block(uint64_t &block_uuid,
+  bool find_all_datanodes_with_block(const uint64_t &block_uuid,
                                      std::vector<std::string> &rdatanodes,
                                      int &error_code);
 

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -270,22 +270,6 @@ enum class ListingResponse {
    */
   u_int64_t get_index_within_block_group(u_int64_t storage_block_id);
 
-  /**
-   * true if the highest bit is set to 1. false otherwise.
-   * @param block_id the id of a block (or a block group)
-   * @return true or false.
-   */
-  bool is_ec_block(u_int64_t block_id);
-
-  /**
-   * Given a block or block group id, returns the path to the corresponding metadata.
-   * For a non EC block, it is BLOCK_LOCATIONS + ID
-   * For an EC block, it is BLOCK_GROUP_LOCATIONS + ID
-   * @param block_or_block_group_id the id of a block or a block group.
-   * @return the path to the corresponding metadata.
-   */
-  std::string get_block_metadata_path(u_int64_t block_or_block_group_id);
-
     /**
    * Abandons the block - basically reverses all of add block's multiops
    */

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -26,11 +26,6 @@ typedef enum class FileStatus : int {
 } FileStatus;
 
 
-const char EC_REPLICATION[15] = {"EC_REPLICATION"};
-const char* DEFAULT_EC_POLICY = EC_REPLICATION;  // the default policy.
-uint32_t DEFAULT_EC_CELLCIZE = 64;  // the default cell size is 64kb.
-uint32_t DEFAULT_EC_ID = 1;
-const char* DEFAULT_EC_CODEC_NAME = "RS64";
 /**
  * This is the basic znode to describe a file
  */
@@ -118,8 +113,13 @@ class ZkNnClient : public ZkClientCommon {
  public:
   char policy;
 
+  const char* EC_REPLICATION = "EC_REPLICATION";
+  const char* DEFAULT_EC_POLICY = EC_REPLICATION;  // the default policy.
+  uint32_t DEFAULT_EC_CELLCIZE = 64;  // the default cell size is 64kb.
+  uint32_t DEFAULT_EC_ID = 1;
+  const char* DEFAULT_EC_CODEC_NAME = "RS64";
 
-  enum class ListingResponse {
+enum class ListingResponse {
       Ok,                   // 0
       FileDoesNotExist,     // 1
       FailedChildRetrieval  // 2

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -270,6 +270,22 @@ class ZkNnClient : public ZkClientCommon {
    */
   u_int64_t get_index_within_block_group(u_int64_t storage_block_id);
 
+  /**
+   * true if the highest bit is set to 1. false otherwise.
+   * @param block_id the id of a block (or a block group)
+   * @return true or false.
+   */
+  bool is_ec_block(u_int64_t block_id);
+
+  /**
+   * Given a block or block group id, returns the path to the corresponding metadata.
+   * For a non EC block, it is BLOCK_LOCATIONS + ID
+   * For an EC block, it is BLOCK_GROUP_LOCATIONS + ID
+   * @param block_or_block_group_id the id of a block or a block group.
+   * @return the path to the corresponding metadata.
+   */
+  std::string get_block_metadata_path(u_int64_t block_or_block_group_id);
+
     /**
    * Abandons the block - basically reverses all of add block's multiops
    */
@@ -296,7 +312,7 @@ class ZkNnClient : public ZkClientCommon {
                                bool newBlock,
                                uint64_t blocksize);
 
-  bool find_all_datanodes_with_block(const std::string &block_uuid_str,
+  bool find_all_datanodes_with_block(uint64_t &block_uuid,
                                      std::vector<std::string> &rdatanodes,
                                      int &error_code);
 

--- a/zookeeper/source/zk_client_common.cc
+++ b/zookeeper/source/zk_client_common.cc
@@ -39,6 +39,20 @@ ZkClientCommon::ZkClientCommon(std::shared_ptr<ZKWrapper> zk_in) : zk(zk_in) {
   init();
 }
 
+bool ZkClientCommon::is_ec_block(u_int64_t block_id) {
+  // & with 1000000...000(63 zeros). If the highest bit is set, this value is
+  // non zero. 0 otherwise.
+  return ((1ull << 63) & block_id) > 0;
+}
+
+std::string ZkClientCommon::get_block_metadata_path(
+        u_int64_t block_or_block_group_id) {
+  if (is_ec_block(block_or_block_group_id))
+    return BLOCK_GROUP_LOCATIONS + std::to_string(block_or_block_group_id);
+  else
+    return BLOCK_LOCATIONS + std::to_string(block_or_block_group_id);
+}
+
 void ZkClientCommon::init() {
   LOG(INFO) << "Initializing ZkClientCommon";
   auto vec = ZKWrapper::get_byte_vector("");

--- a/zookeeper/source/zk_client_common.cc
+++ b/zookeeper/source/zk_client_common.cc
@@ -26,6 +26,7 @@ const char ZkClientCommon::HEALTH_BACKSLASH[] = "/health/";
 const char ZkClientCommon::STATS[] = "/stats";
 const char ZkClientCommon::HEARTBEAT[] = "/heartbeat";
 const char ZkClientCommon::BLOCK_LOCATIONS[] = "/block_locations/";
+const char ZkClientCommon::BLOCK_GROUP_LOCATIONS[] = "/block_group_locations/";
 const char ZkClientCommon::BLOCKS[] = "/blocks";
 
 ZkClientCommon::ZkClientCommon(std::string hostAndIp) {

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -353,7 +353,9 @@ bool ZkNnClient::add_block(AddBlockRequestProto &req,
   std::uint64_t block_id;
   auto data_nodes = std::vector<std::string>();
 
-  if (znode_data.ecPolicyName == EC_REPLICATION) {
+  // TODO(nate): figure out how to store string values in FileZNode.
+  if (true) {
+//  if (znode_data.ecPolicyName == EC_REPLICATION) {
       add_block(file_path, block_id, data_nodes, replication_factor);
   } else {  // case when some EC policy is used.
       // TODO(Nate): generate a block group and each part of a block group.
@@ -514,7 +516,7 @@ bool ZkNnClient::create_file_znode(const std::string &path,
     {
       LOG(INFO) << znode_data->replication << "\n";
       LOG(INFO) << znode_data->owner << "\n";
-      LOG(INFO) << "ec policy name is " << znode_data->ecPolicyName << "\n";
+//      LOG(INFO) << "ec policy name is " << znode_data->ecPolicyName << "\n";
       LOG(INFO) << "size of znode is " << sizeof(*znode_data) << "\n";
     }
     // serialize struct to byte vector
@@ -821,7 +823,7 @@ ZkNnClient::CreateResponse ZkNnClient::create_file(
   znode_data.replication = replication;
   znode_data.blocksize = blocksize;
   znode_data.filetype = IS_FILE;
-  znode_data.ecPolicyName = ecPolicyName;
+//  znode_data.ecPolicyName = ecPolicyName;
 
   // if we failed, then do not set any status
   if (!create_file_znode(path, &znode_data))
@@ -915,7 +917,7 @@ void ZkNnClient::set_mkdir_znode(FileZNode *znode_data) {
   znode_data->blocksize = 0;
   znode_data->replication = 0;
   znode_data->filetype = IS_DIR;
-  znode_data->ecPolicyName = DEFAULT_EC_POLICY;
+//  znode_data->ecPolicyName = DEFAULT_EC_POLICY;
 }
 
 /**
@@ -1278,9 +1280,11 @@ void ZkNnClient::set_file_info(HdfsFileStatusProto *status,
   status->set_access_time(znode_data.access_time);
 
   // If a block is an EC block, optionally set the ecPolicy field.
-  if (znode_data.ecPolicyName != EC_REPLICATION) {
+  // TODO(nate): fix this once I figure out how to save string in znode_data.
+  if (false) {
+//  if (znode_data.ecPolicyName != EC_REPLICATION) {
       ErasureCodingPolicyProto *ecPolicyProto = status->mutable_ecpolicy();
-      ecPolicyProto->set_name(znode_data.ecPolicyName);
+//      ecPolicyProto->set_name(znode_data.ecPolicyName);
       // TODO(nate): check to see if the unit is expected to be in kb.
       ecPolicyProto->set_cellsize(DEFAULT_EC_CELLCIZE);
       ecPolicyProto->set_id(DEFAULT_EC_ID);

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -1868,7 +1868,7 @@ bool ZkNnClient::replicate_blocks(const std::vector<std::string> &to_replicate,
 }
 
 bool ZkNnClient::find_all_datanodes_with_block(
-    uint64_t &block_uuid,
+    const uint64_t &block_uuid,
     std::vector<std::string> &rdatanodes, int &error_code) {
   std::string block_loc_path = get_block_metadata_path(block_uuid);
 

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -1432,20 +1432,6 @@ std::pair<uint32_t, uint32_t> ZkNnClient::get_num_data_parity_blocks(
     return std::make_pair(6, 3);
 }
 
-bool ZkNnClient::is_ec_block(u_int64_t block_id) {
-  // & with 1000000...000(63 zeros). If the highest bit is set, this value is
-  // non zero. 0 otherwise.
-  return ((1ull << 63) & block_id) > 0;
-}
-
-std::string ZkNnClient::get_block_metadata_path(
-        u_int64_t block_or_block_group_id) {
-  if (is_ec_block(block_or_block_group_id))
-    return BLOCK_GROUP_LOCATIONS + std::to_string(block_or_block_group_id);
-  else
-    return BLOCK_LOCATIONS + std::to_string(block_or_block_group_id);
-}
-
 // TODO(2016): To simplify signature, could just get rid of the newBlock param
 // and always check for preexisting replicas
 bool ZkNnClient::find_datanode_for_block(std::vector<std::string> &datanodes,


### PR DESCRIPTION
@jake-nyquist currently, a lot of RPC calls assume that block metadata are located at /block_locations/SOME_BLOCK_ID. 

I created a separate /block_group_locations/ global variable, made a function that takes as input a block id and determines the correct path prefix (either /block_locations/ or /block_group_locations/ depending on the highest bit of the given block_id), and replaced all the hard coded lines that do path concatenation directly (i.e. BLOCK_LOCATIONS + SOME_BLOCK_ID).

When you work on your meta data change stuff, please make metadata changes at /block_group_locations/ or change the "get_block_metadata_path" appropriately please.