### PR TITLE
new proto messages related to a new set of EC RPC calls.

### DIFF
--- a/proto/erasurecoding.proto
+++ b/proto/erasurecoding.proto
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "org.apache.hadoop.hdfs.protocol.proto";
+option java_outer_classname = "ErasureCodingProtos";
+option java_generate_equals_and_hash = true;
+package hadoop.hdfs;
+
+import "hdfs.proto";
+
+message GetErasureCodingPoliciesRequestProto { // void request
+}
+
+message GetErasureCodingPoliciesResponseProto {
+    repeated ErasureCodingPolicyProto ecPolicies = 1;
+}
+
+message GetErasureCodingCodecsRequestProto { // void request
+}
+
+message GetErasureCodingCodecsResponseProto {
+    repeated CodecProto codec = 1;
+}
+
+message GetErasureCodingPolicyRequestProto {
+    required string src = 1; // path to get the policy info
+}
+
+message GetErasureCodingPolicyResponseProto {
+    optional ErasureCodingPolicyProto ecPolicy = 1;
+}
+
+
+/**
+ * Codec and it's corresponding coders
+ */
+message CodecProto {
+    required string codec  = 1;
+    required string coders = 2;
+}


### PR DESCRIPTION
New proto messages

- These are a subset of messages defined at https://github.com/apache/hadoop/blob/d015e0bbd5416943cb4875274e67b7077c00e54b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/proto/erasurecoding.proto

- At this point, we don't support adding, removing, disabling, enabling EC policies; rather, support just the RS(6,3) EC policy.

