### PR TITLE
Fixed error with vagrant provisioning!

### DIFF
--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -5,7 +5,7 @@ set -ex
 ISAL_MIRROR=http://kevinlin.web.rice.edu/static/isal.tar.gz
 
 cd $HOME
-if [ ! -f /tmp/cache/isal ]; then
+if [ ! -d /tmp/cache/isal ]; then
     wget --quiet -O isal.tar.gz $ISAL_MIRROR
     tar -xf isal.tar.gz -C /tmp
     mv /tmp/isa-l_open_src_2.13 /tmp/cache/isal

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -58,9 +58,9 @@ cp /home/vagrant/hadoop3/etc/hadoop/hdfs-site.xml /home/vagrant/hadoop2/etc/hado
 
 # Setup Intel Storage Acceleration Library (ISA-L)
 wget --quiet http://kevinlin.web.rice.edu/static/isal.tar.gz
-tar -xf isa-lopensrc2.13.tar.gz
+tar -xf isal.tar.gz
 mv isa-l_open_src_2.13 /home/vagrant/isal
-rm isa-lopensrc2.13.tar.gz
+rm isal.tar.gz
 cd /home/vagrant/isal
 make
 cd /home/vagrant


### PR DESCRIPTION
In the previous PR, I changed the links to reflect Kevin's static link for ISA-L, but forgot to change the name of the file, causing an error with provisioning vagrant. This PR fixes that bug.