### PR TITLE
Update Zookeeper mirror to Rice server

### DIFF
--- a/.ci/install/zookeeper.sh
+++ b/.ci/install/zookeeper.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-ZOOKEEPER_MIRROR=http://mirror.reverse.net/pub/apache/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz
+ZOOKEEPER_MIRROR=http://kevinlin.web.rice.edu/static/zookeeper-3.4.9.tar.gz
 
 cd $HOME
 if [ ! -f /tmp/cache/zookeeper.tar.gz ]; then

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -56,7 +56,7 @@ cp /home/vagrant/hadoop3/etc/hadoop/hdfs-site.xml /home/vagrant/hadoop2/etc/hado
 
 
 # Setup Apache zookeeper
-wget --quiet http://mirror.reverse.net/pub/apache/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz
+wget --quiet http://kevinlin.web.rice.edu/static/zookeeper-3.4.9.tar.gz
 tar -xf zookeeper-3.4.9.tar.gz
 mv zookeeper-3.4.9 /home/vagrant/zookeeper
 rm zookeeper-3.4.9.tar.gz


### PR DESCRIPTION
Fixes HTTP 404 on existing mirror link.

I believe this is the same tarball; will judge based on CI status.