### PR TITLE
Correctly checks given ecpolicy_name to set if file is ec or not.

### DIFF
--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -1654,7 +1654,7 @@ ZkNnClient::set_erasure_coding_policy_of_path(
 
   // TODO(nate): this boolean flag must change if
   // we support multiple ec policies.
-  if (file_src.empty()) {
+  if (ecpolicy_name.empty()) {
     znode_data.isEC = 0;
   } else {
     znode_data.isEC = 1;


### PR DESCRIPTION
Previously, we were checking the given file path in the SetErasureCodingPolicyRequestProto to see if a file was EC or not, when we should've been checking the given ec policy string. 