### PR TITLE
bug/isal

### DIFF
--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -2,14 +2,15 @@
 
 set -ex
 
-HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1.tar.gz
+HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 
 cd $HOME
-if [ ! -d /tmp/cache/hadoop ]; then
-    wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
-    tar -xf hadoop.tar.gz -C /tmp
-    mv /tmp/hadoop-3.0.0-beta1 /tmp/cache/hadoop
+if [ -d /tmp/cache/hadoop ]; then
+    rm /tmp/cache/hadoop
 fi
+wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
+tar -xf hadoop.tar.gz -C /tmp
+mv /tmp/hadoop-3.0.0-beta1 /tmp/cache/hadoop
 ln -s /tmp/cache/hadoop hadoop
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml
 cp $TRAVIS_BUILD_DIR/config/core-site.xml hadoop/etc/hadoop/core-site.xml

--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -5,12 +5,11 @@ set -ex
 HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 
 cd $HOME
-if [ -d /tmp/cache/hadoop ]; then
-    rm -rf /tmp/cache/hadoop
+if [ ! -d /tmp/cache/hadoop ]; then
+    wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
+    tar -xf hadoop.tar.gz -C /tmp
+    mv /tmp/hadoop-3.0.0-beta1 /tmp/cache/hadoop
 fi
-wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
-tar -xf hadoop.tar.gz -C /tmp
-mv /tmp/hadoop-3.0.0-beta1 /tmp/cache/hadoop
 ln -s /tmp/cache/hadoop hadoop
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml
 cp $TRAVIS_BUILD_DIR/config/core-site.xml hadoop/etc/hadoop/core-site.xml

--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -6,7 +6,7 @@ HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 
 cd $HOME
 if [ -d /tmp/cache/hadoop ]; then
-    rm /tmp/cache/hadoop
+    rm -rf /tmp/cache/hadoop
 fi
 wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
 tar -xf hadoop.tar.gz -C /tmp

--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -5,19 +5,12 @@ set -ex
 ISAL_MIRROR=http://kevinlin.web.rice.edu/static/isal-2.tar.gz
 
 cd $HOME
-if [ -d /tmp/cache/isal ]; then
-    cd /tmp/cache/isal
-    make clean
-    cd $HOME
-    rm -rf /tmp/cache/isal
-fi
 wget --quiet -O isal.tar.gz $ISAL_MIRROR
-tar -xf isal.tar.gz -C /tmp
-mv /tmp/isal /tmp/cache/isal
-cd /tmp/cache/isal
+tar -xf isal.tar.gz
+cd $HOME/isal
 ./autogen.sh
 ./configure
 make
 sudo make install
 cd $HOME
-ln -s /tmp/cache/isal isal
+ln -s $HOME/isal isal

--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -10,7 +10,7 @@ if [ -d /tmp/cache/isal ]; then
 fi
 wget --quiet -O isal.tar.gz $ISAL_MIRROR
 tar -xf isal.tar.gz -C /tmp
-mv /tmp/isa-l_open_src_2.13 /tmp/cache/isal
+mv /tmp/isal /tmp/cache/isal
 cd /tmp/cache/isal
 make && make install
 cd $HOME

--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -2,15 +2,16 @@
 
 set -ex
 
-ISAL_MIRROR=http://kevinlin.web.rice.edu/static/isal.tar.gz
+ISAL_MIRROR=http://kevinlin.web.rice.edu/static/isal-2.tar.gz
 
 cd $HOME
-if [ ! -d /tmp/cache/isal ]; then
-    wget --quiet -O isal.tar.gz $ISAL_MIRROR
-    tar -xf isal.tar.gz -C /tmp
-    mv /tmp/isa-l_open_src_2.13 /tmp/cache/isal
-    cd /tmp/cache/isal
-    make
-    cd $HOME
+if [ -d /tmp/cache/isal ]; then
+    rm -rf /tmp/cache/isal
 fi
+wget --quiet -O isal.tar.gz $ISAL_MIRROR
+tar -xf isal.tar.gz -C /tmp
+mv /tmp/isa-l_open_src_2.13 /tmp/cache/isal
+cd /tmp/cache/isal
+make && make install
+cd $HOME
 ln -s /tmp/cache/isal isal

--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -6,6 +6,9 @@ ISAL_MIRROR=http://kevinlin.web.rice.edu/static/isal-2.tar.gz
 
 cd $HOME
 if [ -d /tmp/cache/isal ]; then
+    cd /tmp/cache/isal
+    make clean
+    cd $HOME
     rm -rf /tmp/cache/isal
 fi
 wget --quiet -O isal.tar.gz $ISAL_MIRROR

--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -12,6 +12,9 @@ wget --quiet -O isal.tar.gz $ISAL_MIRROR
 tar -xf isal.tar.gz -C /tmp
 mv /tmp/isal /tmp/cache/isal
 cd /tmp/cache/isal
-make && make install
+./autogen.sh
+./configure
+make
+sudo make install
 cd $HOME
 ln -s /tmp/cache/isal isal

--- a/isal/CMakeLists.txt
+++ b/isal/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(${CMAKE_SOURCE_DIR}/isal/include)
 
 add_library(isal source/isal_load.c source/erasure_code.c source/gf_util.c source/erasure_coder.c source/dump.c)
-target_link_libraries(isal ~/isal/bin/libisal.so)
+target_link_libraries(isal /usr/lib/libisal.so)
+target_link_libraries(isal /usr/lib/x86_64-linux-gnu/libdl.so)
 target_link_libraries(isal easylogging++)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,7 +107,6 @@ add_executable(ErasureCodeTest isal/ErasureCodeTest.cc)
 target_link_libraries(ErasureCodeTest ${GTEST_LIBRARIES} pthread)
 target_link_libraries(ErasureCodeTest ${GTEST})
 target_link_libraries(ErasureCodeTest isal)
-target_link_libraries(ErasureCodeTest /usr/lib/x86_64-linux-gnu/libdl.so)
 
 add_executable(UsernameTest permissions/UsernameTest.cc)
 target_link_libraries(UsernameTest zkwrapper /usr/local/lib/libzookeeper_mt.so)

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -32,7 +32,7 @@ if [ -d /home/vagrant/hadoop3 ]; then
     rm -rf /home/vagrant/hadoop3
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
-tar -xf hadoop-3.0.0-beta1.tar.gz
+tar -xf hadoop-3.0.0-beta1-2.tar.gz
 mv hadoop-3.0.0-beta1 /home/vagrant/hadoop3
 rm hadoop-3.0.0-beta1.tar.gz
 ln -s hadoop3 hadoop

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -60,15 +60,18 @@ if [ ! -d /home/vagrant/hadoop2 ]; then
 fi
 
 # Setup Intel Storage Acceleration Library (ISA-L)
-if [ ! -d /home/vagrant/isal ]; then
-    wget --quiet http://kevinlin.web.rice.edu/static/isal.tar.gz
-    tar -xf isal.tar.gz
-    mv isa-l_open_src_2.13 /home/vagrant/isal
-    rm isal.tar.gz
-    cd /home/vagrant/isal
-    make
-    cd /home/vagrant
+if [  -d /home/vagrant/isal ]; then
+    rm -rf /home/vagrant/isal
 fi
+wget --quiet http://kevinlin.web.rice.edu/static/isal.tar.gz
+tar -xf isal.tar.gz
+rm isal.tar.gz
+cd /home/vagrant/isal
+./autogen.sh
+./configure
+make
+sudo make install
+cd /home/vagrant
 
 # Setup Apache zookeeper
 if [ -d /home/vagrant/zookeeper ]; then

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -31,7 +31,7 @@ apt-get install -y ssh pdsh openjdk-8-jdk-headless
 if [ -d /home/vagrant/hadoop3 ]; then
     rm -rf /home/vagrant/hadoop3
 fi
-wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1.tar.gz
+wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 tar -xf hadoop-3.0.0-beta1.tar.gz
 mv hadoop-3.0.0-beta1 /home/vagrant/hadoop3
 rm hadoop-3.0.0-beta1.tar.gz

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -34,7 +34,7 @@ fi
 wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 tar -xf hadoop-3.0.0-beta1-2.tar.gz
 mv hadoop-3.0.0-beta1 /home/vagrant/hadoop3
-rm hadoop-3.0.0-beta1.tar.gz
+rm hadoop-3.0.0-beta1-2.tar.gz
 ln -s hadoop3 hadoop
 echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre' >> /home/vagrant/.bashrc
 echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre' >> /home/vagrant/hadoop/etc/hadoop/hadoop-env.sh

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -60,7 +60,10 @@ if [ ! -d /home/vagrant/hadoop2 ]; then
 fi
 
 # Setup Intel Storage Acceleration Library (ISA-L)
-if [  -d /home/vagrant/isal ]; then
+if [ -d /home/vagrant/isal ]; then
+    cd /home/vagrant/isal
+    make clean
+    cd /home/vagrant
     rm -rf /home/vagrant/isal
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/isal-2.tar.gz

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -63,9 +63,9 @@ fi
 if [  -d /home/vagrant/isal ]; then
     rm -rf /home/vagrant/isal
 fi
-wget --quiet http://kevinlin.web.rice.edu/static/isal.tar.gz
-tar -xf isal.tar.gz
-rm isal.tar.gz
+wget --quiet http://kevinlin.web.rice.edu/static/isal-2.tar.gz
+tar -xf isal-2.tar.gz
+rm isal-2.tar.gz
 cd /home/vagrant/isal
 ./autogen.sh
 ./configure


### PR DESCRIPTION
This PR contains the following changes:
- Correctly uses the ISA-L that is from the open source repo provided by Intel. Previously, we were using a non-official version. Works the same way, so just had to change the link and the way we built the library.
- Uses a build of hadoop3 that was compiled from source that uses the ISA-L functionalities. Previously, rdfs could use ISA-L but the hadoop clients could not because it wasn't properly linked. With this new compiled version, both parties can now use ISA-L to ensure fast EC. 