### PR TITLE
hdfs3/hadoop3 alias, default to v2

### DIFF
--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -27,6 +27,10 @@ apt-get install -y ssh pdsh openjdk-8-jdk-headless
 #ssh-keygen -b 2048 -t rsa -f /home/vagrant/.ssh/id_rsa -N ""
 #cp /home/vagrant/.ssh/id_rsa.pub /home/vagrant/.ssh/authorized_keys
 
+# Alias hdfs and hadoop executables
+alias hdfs3="/home/vagrant/hadoop3/bin/hdfs"
+alias hadoop3="/home/vagrant/hadoop3/bin/hadoop"
+
 # Setup Apache hadoop for pseudo-distributed usage
 if [ -d /home/vagrant/hadoop3 ]; then
     rm -rf /home/vagrant/hadoop3
@@ -35,7 +39,6 @@ wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 tar -xf hadoop-3.0.0-beta1-2.tar.gz
 mv hadoop-3.0.0-beta1 /home/vagrant/hadoop3
 rm hadoop-3.0.0-beta1-2.tar.gz
-ln -s hadoop3 hadoop
 echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre' >> /home/vagrant/.bashrc
 echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre' >> /home/vagrant/hadoop/etc/hadoop/hadoop-env.sh
 
@@ -44,20 +47,22 @@ cat /home/vagrant/rdfs/config/hdfs-site.xml > /home/vagrant/hadoop/etc/hadoop/hd
 cat /home/vagrant/rdfs/config/core-site.xml > /home/vagrant/hadoop/etc/hadoop/core-site.xml
 
 # add hadoop to path
-echo 'export PATH=/home/vagrant/hadoop/bin:$PATH' >> /home/vagrant/.bashrc
+echo 'export PATH=/home/vagrant/hadoop2/bin:$PATH' >> /home/vagrant/.bashrc
 
 # add hadoop to classpath
 echo 'export CLASSPATH=/home/vagrant/hadoop/share/hadoop/hdfs/*:/home/vagrant/hadoop/share/hadoop/common/*' >> /home/vagrant/.bashrc
 
 # Download hadoop 2.7.4 as well, but do not set as default.
-if [ ! -d /home/vagrant/hadoop2 ]; then
-    wget --quiet http://mirror.cc.columbia.edu/pub/software/apache/hadoop/common/hadoop-2.7.4/hadoop-2.7.4.tar.gz
-    tar -xf hadoop-2.7.4.tar.gz
-    mv hadoop-2.7.4 /home/vagrant/hadoop2
-    rm hadoop-2.7.4.tar.gz
-    cp /home/vagrant/hadoop3/etc/hadoop/core-site.xml /home/vagrant/hadoop2/etc/hadoop/core-site.xml
-    cp /home/vagrant/hadoop3/etc/hadoop/hdfs-site.xml /home/vagrant/hadoop2/etc/hadoop/hdfs-site.xml
+if [ -d /home/vagrant/hadoop2 ]; then
+    rm -rf /home/vagrant/hadoop2
 fi
+wget --quiet http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
+tar -xf hadoop-2.8.1.tar.gz
+mv hadoop-2.8.1 /home/vagrant/hadoop2
+rm hadoop-2.8.1.tar.gz
+ln -s hadoop2 hadoop
+cp /home/vagrant/hadoop3/etc/hadoop/core-site.xml /home/vagrant/hadoop2/etc/hadoop/core-site.xml
+cp /home/vagrant/hadoop3/etc/hadoop/hdfs-site.xml /home/vagrant/hadoop2/etc/hadoop/hdfs-site.xml
 
 # Setup Intel Storage Acceleration Library (ISA-L)
 if [ -d /home/vagrant/isal ]; then


### PR DESCRIPTION
Not totally sure if this alleviates any client-side confusion, but this change retains Hadoop 2.8.1 as the default hdfs/hadoop version and aliases 3.0.0-beta as `hdfs3` and `hadoop3` in the dev VM. Since we have previously been relying on the v2 client API, any clients explicitly needing v3 should use `hdfs3` in the command line.

The HDFS client executable unfortunately internally relies on relative paths from the CWD of the executable, so I had to alias it rather than symlinking the executable from `/usr/local/bin` or something like that.