### PR TITLE
Redirect ISAL compilation output to /dev/null

### DIFF
--- a/.ci/install/isal.sh
+++ b/.ci/install/isal.sh
@@ -8,8 +8,8 @@ cd $HOME
 wget --quiet -O isal.tar.gz $ISAL_MIRROR
 tar -xf isal.tar.gz
 cd $HOME/isal
-./autogen.sh
-./configure
-make
-sudo make install
+./autogen.sh > /dev/null
+./configure > /dev/null
+make > /dev/null
+sudo make install > /dev/null
 cd $HOME


### PR DESCRIPTION
Motivation: Reduce stdout noise in Travis logs, esp. since we generate enough logs that we're close to the log file size limit.