### PR TITLE
Hostname comp413.local as 127.0.0.1 in /etc/hosts

### DIFF
--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -190,6 +190,7 @@ echo 'sudo chown vagrant:vagrant /dev/sdb' >> /home/vagrant/.bashrc
 # Consider the webRDFS self-signed certificate a trusted root CA.
 cp ~/rdfs/config/keys/server.crt /usr/local/share/ca-certificates/
 update-ca-certificates
+echo '127.0.0.1 comp413.local' >> /etc/hosts
 
 # add diff detector to path
 echo 'python /home/vagrant/rdfs/utility/provision_diff.py' >> /home/vagrant/.bashrc


### PR DESCRIPTION
Follow-up to #203. Need to add the new CN `comp413.local` in Vagrant /etc/hosts.