### PR TITLE
Frontend handler for serving static client file

### DIFF
--- a/test/webRDFS/WebServerTest.cc
+++ b/test/webRDFS/WebServerTest.cc
@@ -77,6 +77,12 @@ TEST(WebServerTest, testRename) {
   system("hdfs dfs -fs hdfs://comp413.local:5351 -rm /fileToRename");
 }
 
+TEST(WebServerTest, testFrontend) {
+  ASSERT_EQ(0, system("curl -i https://comp413.local:8080 > frontend"));
+  ASSERT_EQ(0, system("grep \"Content-Type: text/html\" frontend"));
+  ASSERT_EQ(0, system("rm frontend"));
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/web-rdfs/include/http_handlers.h
+++ b/web-rdfs/include/http_handlers.h
@@ -16,6 +16,16 @@ using HttpsServer = SimpleWeb::Server<SimpleWeb::HTTPS>;
 void setZk(zkclient::ZkNnClient *zk_arg);
 
 /**
+ * Handler invoked when the client issues a GET request to the web server root
+ * path. This is a request for the webRDFS client/frontend.
+ *
+ * @param response HTTP response object.
+ * @param request HTTP request object.
+ */
+void frontend_handler(std::shared_ptr<HttpsServer::Response> response,
+                      std::shared_ptr<HttpsServer::Request> request);
+
+/**
  * Handler invoked when a client issues a GET request for an RDFS path.
  *
  * @param response HTTP response object.

--- a/web-rdfs/source/http_handlers.cc
+++ b/web-rdfs/source/http_handlers.cc
@@ -7,7 +7,7 @@
 #include <iostream>
 
 // Path to the HTML file containing the webRDFS client.
-#define WEBRDFS_CLIENT_STATIC_FILE "/home/vagrant/rdfs/web-rdfs/source/index.html"
+#define WEBRDFS_CLIENT_FILE "/home/vagrant/rdfs/web-rdfs/source/index.html"
 
 zkclient::ZkNnClient *zk;
 
@@ -218,7 +218,7 @@ void frontend_handler(std::shared_ptr<HttpsServer::Response> response,
                       std::shared_ptr<HttpsServer::Request> request) {
   LOG(DEBUG) << "Frontend handler invoked";
 
-  serve_static_file(response, "text/html", WEBRDFS_CLIENT_STATIC_FILE);
+  serve_static_file(response, "text/html", WEBRDFS_CLIENT_FILE);
 }
 
 void get_handler(std::shared_ptr<HttpsServer::Response> response,

--- a/web-rdfs/source/index.html
+++ b/web-rdfs/source/index.html
@@ -1,0 +1,1 @@
+placeholder content

--- a/web-rdfs/source/web_rdfs_server.cc
+++ b/web-rdfs/source/web_rdfs_server.cc
@@ -20,6 +20,9 @@ void WebRDFSServer::start() {
   WebRDFSServer::register_handler("^/webhdfs/v1/.+$",
                                   HTTP_DELETE,
                                   delete_handler);
+  WebRDFSServer::register_handler("^/$",
+                                  HTTP_GET,
+                                  frontend_handler);
 
   server.start();
 }


### PR DESCRIPTION
### Motivation

Add server-side endpoint to allow webRDFS server to serve client frontend directly. Since it's coming from the same host, we don't need to worry about any CORS weirdness.

### Changeset

* Add `serve_static_file` utility
* Added placeholder `index.html` (to be replaced by client, once complete)
* Add `frontend_handler` for GET requests to the root path

### Testing

* New test `testFrontend` added