### PR TITLE
Install hadoop2 on CI, specify hadoop2 bin for AppendFileTest

### DIFF
--- a/.ci/install/hadoop.sh
+++ b/.ci/install/hadoop.sh
@@ -2,14 +2,21 @@
 
 set -ex
 
-HADOOP_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
+HADOOP2_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
+HADOOP3_MIRROR=http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 
 cd $HOME
-if [ ! -d /tmp/cache/hadoop ]; then
-    wget --quiet -O hadoop.tar.gz $HADOOP_MIRROR
+if [ ! -d /tmp/cache/hadoop3 ]; then
+    wget --quiet -O hadoop.tar.gz $HADOOP3_MIRROR
     tar -xf hadoop.tar.gz -C /tmp
-    mv /tmp/hadoop-3.0.0-beta1 /tmp/cache/hadoop
+    mv /tmp/hadoop-3.0.0-beta1 /tmp/cache/hadoop3
 fi
-ln -s /tmp/cache/hadoop hadoop
+if [ ! -d /tmp/cache/hadoop2 ]; then
+    wget --quiet -O hadoop.tar.gz $HADOOP2_MIRROR
+    tar -xf hadoop.tar.gz -C /tmp
+    mv /tmp/hadoop-2.8.1 /tmp/cache/hadoop2
+fi
+ln -s /tmp/cache/hadoop3 hadoop
+ln -s /tmp/cache/hadoop2 hadoop-legacy
 cp $TRAVIS_BUILD_DIR/config/hdfs-site.xml hadoop/etc/hadoop/hdfs-site.xml
 cp $TRAVIS_BUILD_DIR/config/core-site.xml hadoop/etc/hadoop/core-site.xml

--- a/.ci/test/main.sh
+++ b/.ci/test/main.sh
@@ -30,4 +30,4 @@ run_test ./ZKWrapperTest
 run_test ./UsernameTest
 run_test ./LeaseTest
 run_test ./AppendTestMJP
-run_test ./AppendFileTest
+PATH=/home/vagrant/hadoop-legacy/bin:$PATH run_test ./AppendFileTest


### PR DESCRIPTION
This change adds hadoop2 to the CI build in addition to the existing v3 default, and overrides the `hdfs` binary path specifically for `AppendFileTest`.