### PR TITLE
Cleanup vagrant_provision.sh

### DIFF
--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -15,11 +15,13 @@ apt-get install -y git build-essential cmake automake autoconf libtool libboost-
 
 apt-get install -y yasm
 
-wget --quiet https://github.com/google/protobuf/releases/download/v3.0.0/protobuf-cpp-3.0.0.tar.gz
-tar -xf protobuf-cpp-3.0.0.tar.gz
-rm protobuf-cpp-3.0.0.tar.gz
-cd protobuf-3.0.0; ./autogen.sh && ./configure --prefix=/usr && make && make install
-cd /home/vagrant/; ldconfig
+if [ ! -d /home/vagrant/protobuf-3.0.0 ]; then
+    wget --quiet https://github.com/google/protobuf/releases/download/v3.0.0/protobuf-cpp-3.0.0.tar.gz
+    tar -xf protobuf-cpp-3.0.0.tar.gz
+    rm protobuf-cpp-3.0.0.tar.gz
+    cd protobuf-3.0.0; ./autogen.sh && ./configure --prefix=/usr && make && make install
+    cd /home/vagrant/; ldconfig
+fi
 
 # Install and setup dependencies of hadoop
 apt-get install -y ssh pdsh openjdk-8-jdk-headless
@@ -35,6 +37,9 @@ alias hadoop3="/home/vagrant/hadoop3/bin/hadoop"
 if [ -d /home/vagrant/hadoop3 ]; then
     rm -rf /home/vagrant/hadoop3
 fi
+if [ -f hadoop-3.0.0-beta1-2.tar.gz ]; then
+    rm -f hadoop-3.0.0-beta1-2.tar.gz
+fi
 wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 tar -xf hadoop-3.0.0-beta1-2.tar.gz
 mv hadoop-3.0.0-beta1 /home/vagrant/hadoop3
@@ -47,14 +52,18 @@ cat /home/vagrant/rdfs/config/hdfs-site.xml > /home/vagrant/hadoop3/etc/hadoop/h
 cat /home/vagrant/rdfs/config/core-site.xml > /home/vagrant/hadoop3/etc/hadoop/core-site.xml
 
 # add hadoop to path
-echo 'export PATH=/home/vagrant/hadoop2/bin:$PATH' >> /home/vagrant/.bashrc
+echo 'export PATH=${PATH//:\/home\/vagrant\/hadoop2\/bin:/:}' >> /home/vagrant/.bashrc
+echo 'export PATH=/home/vagrant/hadoop/bin:$PATH' >> /home/vagrant/.bashrc
 
 # add hadoop to classpath
 echo 'export CLASSPATH=/home/vagrant/hadoop3/share/hadoop/hdfs/*:/home/vagrant/hadoop3/share/hadoop/common/*' >> /home/vagrant/.bashrc
 
-# Download hadoop 2.7.4 as well, but do not set as default.
+# Download hadoop 2.8.1 as well
 if [ -d /home/vagrant/hadoop2 ]; then
     rm -rf /home/vagrant/hadoop2
+fi
+if [ -f hadoop-2.8.1.tar.gz ]; then
+    rm -f hadoop-2.8.1.tar.gz
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 tar -xf hadoop-2.8.1.tar.gz
@@ -71,6 +80,9 @@ if [ -d /home/vagrant/isal ]; then
     cd /home/vagrant
     rm -rf /home/vagrant/isal
 fi
+if [ -f isal-2.tar.gz ]; then
+    rm -f isal-2.tar.gz
+fi
 wget --quiet http://kevinlin.web.rice.edu/static/isal-2.tar.gz
 tar -xf isal-2.tar.gz
 rm isal-2.tar.gz
@@ -84,6 +96,9 @@ cd /home/vagrant
 # Setup Apache zookeeper
 if [ -d /home/vagrant/zookeeper ]; then
     rm -rf /home/vagrant/zookeeper
+fi
+if [ -f zookeeper-3.4.9.tar.gz ]; then
+    rm -f zookeeper-3.4.9.tar.gz
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/zookeeper-3.4.9.tar.gz
 tar -xf zookeeper-3.4.9.tar.gz
@@ -143,32 +158,40 @@ apt-get --assume-yes install libtool
 autoreconf -if
 ./configure
 make && make install
+cd /home/vagrant
 
 # Add Google Mock
-apt-get install -y google-mock
-cd /usr/src/gmock
-cmake CMakeLists.txt
-make
-cp *.a /usr/lib
+if [! -d /usr/src/gmock ]; then
+    apt-get install -y google-mock
+    cd /usr/src/gmock
+    cmake CMakeLists.txt
+    make
+    cp *.a /usr/lib
+    cd /home/vagrant
+fi
 
 # Add Google Test
-apt-get install -y libgtest-dev
-cd /usr/src/gtest
-cmake CMakeLists.txt
-make
-cp *.a /usr/lib
-cd /home/vagrant
+if [ ! -d /usr/src/gtest ]; then
+    apt-get install -y libgtest-dev
+    cd /usr/src/gtest
+    cmake CMakeLists.txt
+    make
+    cp *.a /usr/lib
+    cd /home/vagrant
+fi
 
 # Add Valgrind
 sudo apt-get install -y libc6-dbg
-mkdir valgrindtemp
-cd valgrindtemp
-wget --quiet http://valgrind.org/downloads/valgrind-3.11.0.tar.bz2
-tar -xf valgrind-3.11.0.tar.bz2
-cd valgrind-3.11.0
-./configure --prefix=/usr && sudo make && sudo make install
-cd ../..
-rm -r valgrindtemp
+if [ ! -d /usr/lib/valgrind ]; then
+    mkdir valgrindtemp
+    cd valgrindtemp
+    wget --quiet http://valgrind.org/downloads/valgrind-3.11.0.tar.bz2
+    tar -xf valgrind-3.11.0.tar.bz2
+    cd valgrind-3.11.0
+    ./configure --prefix=/usr && sudo make && sudo make install
+    cd ../..
+    rm -r valgrindtemp
+fi
 
 # Download demo tables.
 if [ ! -d /home/vagrant/demo_script ]; then

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -38,7 +38,7 @@ if [ -d /home/vagrant/hadoop3 ]; then
     rm -rf /home/vagrant/hadoop3
 fi
 if [ -f hadoop-3.0.0-beta1-2.tar.gz ]; then
-    rm -f hadoop-3.0.0-beta1-2.tar.gz
+    rm -f hadoop-3.0.0-beta1-2.tar.gz*
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/hadoop-3.0.0-beta1-2.tar.gz
 tar -xf hadoop-3.0.0-beta1-2.tar.gz
@@ -63,7 +63,7 @@ if [ -d /home/vagrant/hadoop2 ]; then
     rm -rf /home/vagrant/hadoop2
 fi
 if [ -f hadoop-2.8.1.tar.gz ]; then
-    rm -f hadoop-2.8.1.tar.gz
+    rm -f hadoop-2.8.1.tar.gz*
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 tar -xf hadoop-2.8.1.tar.gz
@@ -81,7 +81,7 @@ if [ -d /home/vagrant/isal ]; then
     rm -rf /home/vagrant/isal
 fi
 if [ -f isal-2.tar.gz ]; then
-    rm -f isal-2.tar.gz
+    rm -f isal-2.tar.gz*
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/isal-2.tar.gz
 tar -xf isal-2.tar.gz
@@ -98,7 +98,7 @@ if [ -d /home/vagrant/zookeeper ]; then
     rm -rf /home/vagrant/zookeeper
 fi
 if [ -f zookeeper-3.4.9.tar.gz ]; then
-    rm -f zookeeper-3.4.9.tar.gz
+    rm -f zookeeper-3.4.9.tar.gz*
 fi
 wget --quiet http://kevinlin.web.rice.edu/static/zookeeper-3.4.9.tar.gz
 tar -xf zookeeper-3.4.9.tar.gz

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -161,7 +161,7 @@ make && make install
 cd /home/vagrant
 
 # Add Google Mock
-if [! -d /usr/src/gmock ]; then
+if [ ! -d /usr/src/gmock ]; then
     apt-get install -y google-mock
     cd /usr/src/gmock
     cmake CMakeLists.txt


### PR DESCRIPTION
Removes unnessary redundant downloads to speed up re-provisioning.
- Gtest, Gmock, Valgrind, and Protobuf are checked to see if they're already existing. The valgrind and protobuf installations take a long time, so not doing it again speeds up re-provisioning.

Checks to see if an existing tar file is already installed and deletes it before downloading again.
- Turns out that if provisioning fails due to different reasons (spotty internet connection being one of them), then the corrupted tar files that were downloaded are kept, and newer downloads are named as something.tar.gz1, something.tar.gz2, etc. This causes provisioning to fail every single time after such cases since it tries to un-tar the corrupted tar file instead of the newly download ones. Therefore, I changed it so that all those previous tar files are deleted before attempting to download new ones.

Fixes $PATH so that conversion between hadoop2 and hadoop3 is easier.
- Previously, hadoop2 was set in path, which makes conversion between hadoop2 and hadoop3 difficult (had to remove hadoop2 from PATH variable using `export PATH=${PATH//:\/home\/vagrant\/hadoop2\/bin:/:}`) But since /home/vagrant/hadoop/bin is in PATH, then we can remove that unnecessary PATH variable and simply use the symlink. For example, right now by default, we have hadoop2 linked to hadoop (ln -s hadoop2 hadoop in line 72). If we wanted to switch to using hadoop3, we can simply go to /home/vagrant, call `rm hadoop` and do `ln -s hadoop3 hadoop` and it'll change. Same goes for going from hadoop3 to hadoop2. This change doesn't change anything that others will be working with. It simply makes it easier for storage team to convert from hadoop2 to hadoop3.