### PR TITLE
Make http handlers able to handle username

### DIFF
--- a/test/webRDFS/WebServerTest.cc
+++ b/test/webRDFS/WebServerTest.cc
@@ -16,8 +16,9 @@ TEST(WebServerTest, testDelete) {
 
   ASSERT_EQ(0,
             system("curl -i -X DELETE "
-                   "https://comp413.local:8080/webhdfs/v1/"
-                   "fileToDelete?op=DELETE > actualResultDelete"));
+                   "\"https://comp413.local:8080/webhdfs/v1/"
+                   "fileToDelete?user.name=vagrant&op=DELETE\" > "
+                   "actualResultDelete"));
 
   // Check that results match
   ASSERT_EQ(0,
@@ -33,8 +34,9 @@ TEST(WebServerTest, testRead) {
         "-copyFromLocal fileForTesting /fileToRead");
 
   ASSERT_EQ(0,
-            system("curl -i https://comp413.local:8080/webhdfs/v1/"
-                  "fileToRead?op=OPEN > actualResultRead"));
+            system("curl -i \"https://comp413.local:8080/webhdfs/v1/"
+                  "fileToRead?user.name=vagrant&op=OPEN\" > "
+                  "actualResultRead"));
 
   // Check that results match
   ASSERT_EQ(0,
@@ -48,8 +50,9 @@ TEST(WebServerTest, testRead) {
 TEST(WebServerTest, testMkdir) {
   ASSERT_EQ(0,
             system("curl -i -X PUT "
-                   "https://comp413.local:8080/webhdfs/v1/"
-                   "pathToCreate?op=MKDIRS > actualResultMkdir"));
+                   "\"https://comp413.local:8080/webhdfs/v1/"
+                   "pathToCreate?user.name=vagrant&op=MKDIRS\" "
+                   "> actualResultMkdir"));
 
   // Check that results match
   ASSERT_EQ(0,
@@ -65,8 +68,8 @@ TEST(WebServerTest, testRename) {
 
   system("curl -i -X PUT "
                    "\"https://comp413.local:8080/webhdfs/v1/"
-                   "fileToRename?op=RENAME&destination=newPath\" > "
-                   "actualResultRename");
+                   "fileToRename?user.name=vagrant&op=RENAME&destination="
+                   "/newPath\" > actualResultRename");
 
   // Check that results match
   ASSERT_EQ(0,
@@ -75,6 +78,7 @@ TEST(WebServerTest, testRename) {
 
   system("rm actualResultRename");
   system("hdfs dfs -fs hdfs://comp413.local:5351 -rm /fileToRename");
+  system("hdfs dfs -fs hdfs://comp413.local:5351 -rm /newPath");
 }
 
 TEST(WebServerTest, testFrontend) {
@@ -90,7 +94,8 @@ TEST(WebServerTest, testCreate) {
 
   system("curl -i -X PUT "
                    "\"https://comp413.local:8080/webhdfs/v1/"
-                   "fileToCreate?op=CREATE\" > actualResultCreate");
+                   "fileToCreate?user.name=vagrant&op=CREATE\" > "
+                   "actualResultCreate");
 
   // Check that results match
   ASSERT_EQ(0,
@@ -111,8 +116,9 @@ TEST(WebServerTest, testListing) {
            "/dirToLs/");
 
   ASSERT_EQ(0,
-            system("curl -i https://comp413.local:8080/webhdfs/v1/"
-                           "dirToLs?op=LISTSTATUS > actualResultLs"));
+            system("curl -i \"https://comp413.local:8080/webhdfs/v1/"
+                           "dirToLs?user.name=vagrant&op=LISTSTATUS\" > "
+                           "actualResultLs"));
 
   // Check that results match except for the access times
   ASSERT_EQ(0,

--- a/web-rdfs/source/http_handlers.cc
+++ b/web-rdfs/source/http_handlers.cc
@@ -56,8 +56,9 @@ std::string get_path(std::shared_ptr<HttpsServer::Request> request) {
   return path;
 }
 
-std::map<std::string, std::string> parseURL(std::shared_ptr
-                                            <HttpsServer::Request> request) {
+std::map<std::string, std::string> parseQueryString(std::shared_ptr
+                                                    <HttpsServer::Request>
+                                                    request) {
   LOG(DEBUG) << "Parsing " << request->query_string;
 
   std::map<std::string, std::string> queryValues;
@@ -230,7 +231,7 @@ void frontend_handler(std::shared_ptr<HttpsServer::Response> response,
 
 void get_handler(std::shared_ptr<HttpsServer::Response> response,
                  std::shared_ptr<HttpsServer::Request> request) {
-  std::map<std::string, std::string> requestInfo = parseURL(request);
+  std::map<std::string, std::string> requestInfo = parseQueryString(request);
   std::string typeOfRequest = requestInfo["op"];
 
   if (!typeOfRequest.compare("OPEN")) {
@@ -245,7 +246,7 @@ void get_handler(std::shared_ptr<HttpsServer::Response> response,
 
 void post_handler(std::shared_ptr<HttpsServer::Response> response,
                   std::shared_ptr<HttpsServer::Request> request) {
-  std::map<std::string, std::string> requestInfo = parseURL(request);
+  std::map<std::string, std::string> requestInfo = parseQueryString(request);
   std::string typeOfRequest = requestInfo["op"];
 
   if (!typeOfRequest.compare("APPEND")) {
@@ -257,10 +258,10 @@ void post_handler(std::shared_ptr<HttpsServer::Response> response,
 
 void put_handler(std::shared_ptr<HttpsServer::Response> response,
                  std::shared_ptr<HttpsServer::Request> request) {
-  std::map<std::string, std::string> requestInfo = parseURL(request);
+  std::map<std::string, std::string> requestInfo = parseQueryString(request);
   std::string typeOfRequest = requestInfo["op"];
 
-  parseURL(request);
+  parseQueryString(request);
   if (!typeOfRequest.compare("MKDIRS")) {
     mkdir_handler(response, requestInfo);
   } else if (!typeOfRequest.compare("RENAME")) {
@@ -276,7 +277,7 @@ void put_handler(std::shared_ptr<HttpsServer::Response> response,
 
 void delete_handler(std::shared_ptr<HttpsServer::Response> response,
                     std::shared_ptr<HttpsServer::Request> request) {
-  std::map<std::string, std::string> requestInfo = parseURL(request);
+  std::map<std::string, std::string> requestInfo = parseQueryString(request);
   std::string typeOfRequest = requestInfo["op"];
 
   if (!typeOfRequest.compare("DELETE")) {

--- a/web-rdfs/source/http_handlers.cc
+++ b/web-rdfs/source/http_handlers.cc
@@ -62,18 +62,21 @@ std::map<std::string, std::string> parseURL(std::shared_ptr
 
   std::map<std::string, std::string> queryValues;
   queryValues["path"] = get_path(request);
-  char *givenValues = strtok((char*)request->query_string.c_str(), "&");
+  char *save;
+  char *givenValues = strtok_r(const_cast<char*>(
+                                 request->query_string.c_str()), "&", &save);
 
-  while (givenValues != NULL)
-  {
+  while (givenValues != NULL) {
     std::string currentVal = std::string(givenValues);
     int idxOfSplit = currentVal.rfind("=");
-    queryValues[currentVal.substr(0, idxOfSplit)] = currentVal.substr(idxOfSplit + 1);
-    givenValues = strtok(NULL, "&");
+    queryValues[
+                currentVal.substr(0, idxOfSplit)
+               ] = currentVal.substr(idxOfSplit + 1);
+    givenValues = strtok_r(NULL, "&", &save);
   }
 
   return queryValues;
-};
+}
 
 void create_file_handler(std::shared_ptr<HttpsServer::Response> response,
                          std::map<std::string, std::string> requestInfo) {

--- a/web-rdfs/source/web_request_translator.cc
+++ b/web-rdfs/source/web_request_translator.cc
@@ -38,7 +38,11 @@ namespace webRequestTranslator {
    */
   std::string getRenameResponse(zkclient::ZkNnClient::RenameResponse
                                 &resProto) {
-    return "{\"boolean\":true}\n";
+    if (resProto == zkclient::ZkNnClient::RenameResponse::Ok) {
+      return "{\"boolean\":true}\n";
+    } else {
+      return "{\"boolean\":false}\n";
+    }
   }
 
   /**


### PR DESCRIPTION
Generalize the url parsing in webRDFS so it can handle usernames. Fixed tests to reflect this change. Also removed stubbed value in rename call.