### PR TITLE
Activate two more append tests

### DIFF
--- a/test/integration/AppendFileTest.cc
+++ b/test/integration/AppendFileTest.cc
@@ -385,7 +385,9 @@ int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::GTEST_FLAG(filter) =
   "AppendFileTest.testSimpleFileAppend:"
-    "AppendFileTest.testSimpleFileSmallAppend";
+    "AppendFileTest.testSimpleFileSmallAppend:"
+      "AppendFileTest.testAppendToNonExistentFile:"
+        "AppendFileTest.testOneClientAppends";
   int res = RUN_ALL_TESTS();
   // NOTE: You'll need to scroll up a bit to see the test results
 


### PR DESCRIPTION
This PR enables two more append tests:
1. Append to a file that does not already exist in RDFS
2. Have a separate client append to a file in RDFS  and make sure this change is seen in another client.