### PR TITLE
Add webRDFS config and req/res logging

### DIFF
--- a/config/webrdfs-log-conf.conf
+++ b/config/webrdfs-log-conf.conf
@@ -1,0 +1,19 @@
+* GLOBAL:
+   FORMAT               =  "%datetime{%Y-%M-%d %H:%m:%s.%g} [%level] <%fbase>: %msg"
+   FILENAME             =  "logs/webrdfs-log.log"
+   ENABLED              =  true
+   TO_FILE              =  false
+   TO_STANDARD_OUTPUT   =  true
+   MILLISECONDS_WIDTH   =  6
+   PERFORMANCE_TRACKING =  true
+   MAX_LOG_FILE_SIZE    =  2097152 ## 2MB
+   LOG_FLUSH_THRESHOLD  =  1
+* INFO:
+   TO_FILE              = true
+* DEBUG:
+   FORMAT               = "%datetime{%Y-%M-%d %H:%m:%s.%g} [%level] <%loc>: %msg"
+* ERROR:
+   FORMAT               = "%datetime{%Y-%M-%d %H:%m:%s.%g} [%level] <%loc>: %msg"
+* FATAL:
+   FORMAT               = "%datetime{%Y-%M-%d %H:%m:%s.%g} [%level] <%loc>: %msg"
+   LOG_FLUSH_THRESHOLD  = 1 ##the application abort()s after a fatal event, so flush immediately

--- a/web-rdfs/source/main.cc
+++ b/web-rdfs/source/main.cc
@@ -10,7 +10,7 @@
 
 INITIALIZE_EASYLOGGINGPP
 
-#define LOG_CONFIG_FILE "/home/vagrant/rdfs/config/nn-log-conf.conf"
+#define LOG_CONFIG_FILE "/home/vagrant/rdfs/config/webrdfs-log-conf.conf"
 
 static inline void parse_cmdline_options(int argc,
                                          char *argv[],

--- a/web-rdfs/source/web_rdfs_server.cc
+++ b/web-rdfs/source/web_rdfs_server.cc
@@ -5,7 +5,7 @@
 #include "http_handlers.h"
 
 void WebRDFSServer::start() {
-  LOG(INFO) << "WebRDFS listening on port " << server.config.port;
+  LOG(DEBUG) << "WebRDFS listening on port " << server.config.port;
 
   // Register all handlers.
   WebRDFSServer::register_handler("^/webhdfs/v1/.+$",


### PR DESCRIPTION
This changes adds request/response logging to disk for webRDFS requests for purposes of tracing the behavior of the server after clients issue requests.

Logs are in `build/web-rdfs/logs/webrdfs-log.log`

Requested by @rzhang0720 