### PR TITLE
Default to hdfs v3

### DIFF
--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -30,8 +30,8 @@ apt-get install -y ssh pdsh openjdk-8-jdk-headless
 #cp /home/vagrant/.ssh/id_rsa.pub /home/vagrant/.ssh/authorized_keys
 
 # Alias hdfs and hadoop executables
-alias hdfs3="/home/vagrant/hadoop3/bin/hdfs"
-alias hadoop3="/home/vagrant/hadoop3/bin/hadoop"
+alias hdfs2="/home/vagrant/hadoop2/bin/hdfs"
+alias hadoop2="/home/vagrant/hadoop2/bin/hadoop"
 
 # Setup Apache hadoop for pseudo-distributed usage
 if [ -d /home/vagrant/hadoop3 ]; then
@@ -69,7 +69,7 @@ wget --quiet http://kevinlin.web.rice.edu/static/hadoop-2.8.1.tar.gz
 tar -xf hadoop-2.8.1.tar.gz
 mv hadoop-2.8.1 /home/vagrant/hadoop2
 rm hadoop-2.8.1.tar.gz
-ln -s hadoop2 hadoop
+ln -s hadoop3 hadoop
 cp /home/vagrant/hadoop3/etc/hadoop/core-site.xml /home/vagrant/hadoop2/etc/hadoop/core-site.xml
 cp /home/vagrant/hadoop3/etc/hadoop/hdfs-site.xml /home/vagrant/hadoop2/etc/hadoop/hdfs-site.xml
 


### PR DESCRIPTION
HDFS client v2 no longer needs to be used as of #220 and #239.