### PR TITLE
ZKWrapper improvements

### DIFF
--- a/rice-datanode/source/main.cc
+++ b/rice-datanode/source/main.cc
@@ -158,7 +158,8 @@ int main(int argc, char *argv[]) {
     auto data = std::vector<uint8_t>();
     if (!zk_shared->get("/process_of_record",
                         data,
-                        error_code)) {
+                        error_code,
+                        true)) {
       LOG(ERROR) << "Unable to get process of record";
       exit(1);
     }

--- a/rice-namenode/source/main.cc
+++ b/rice-namenode/source/main.cc
@@ -177,7 +177,8 @@ int main(int argc, char *argv[]) {
           auto data = std::vector<uint8_t>();
           if (!zk_shared->get("/process_of_record",
                               data,
-                              error_code)) {
+                              error_code,
+                              true)) {
               LOG(ERROR) << "Unable to get process of record";
               exit(1);
           }
@@ -216,7 +217,8 @@ int main(int argc, char *argv[]) {
                   auto data = std::vector<uint8_t>();
                   if (!zk_shared->get("/process_of_record",
                                       data,
-                                      error_code)) {
+                                      error_code,
+                                      true)) {
                       LOG(ERROR) << "Unable to get process of record";
                       exit(1);
                   }

--- a/storage/source/StorageMetrics.cc
+++ b/storage/source/StorageMetrics.cc
@@ -29,7 +29,7 @@ float StorageMetrics::usedSpaceFraction() {
     std::string statsPath = "/health/" + datanodeId + "/stats";
     std::vector<std::uint8_t> statsPayload = std::vector<std::uint8_t>();
     statsPayload.resize(sizeof(DataNodePayload));
-    if (!zkWrapper->get(statsPath, statsPayload, error)) {
+    if (!zkWrapper->get(statsPath, statsPayload, error, false)) {
       LOG(ERROR) << "Failed to get " << statsPath;
       return 0;
     }
@@ -52,7 +52,7 @@ float StorageMetrics::usedSpace() {
     std::string statsPath = "/health/" + datanodeId + "/stats";
     std::vector<std::uint8_t> statsPayload = std::vector<std::uint8_t>();
     statsPayload.resize(sizeof(DataNodePayload));
-    if (!zkWrapper->get(statsPath, statsPayload, error)) {
+    if (!zkWrapper->get(statsPath, statsPayload, error, false)) {
       LOG(ERROR) << "Failed to get " << statsPath;
       return 0;
     }

--- a/test/namenode/NameNodeTest.cc
+++ b/test/namenode/NameNodeTest.cc
@@ -14,13 +14,13 @@ void NamenodeTest::SetUp() {
             std::make_shared<ZKWrapper>("localhost:2181",
             error_code, "/testing");
     assert(error_code == 0);  // Z_OK
-    client = new zkclient::ZkNnClient(zk_shared);
-    zk = new ZKWrapper("localhost:2181", error_code, "/testing");
+    client = std::unique_ptr<zkclient::ZkNnClient>{
+        new zkclient::ZkNnClient(zk_shared)};
+    zk = std::unique_ptr<ZKWrapper>{
+        new ZKWrapper("localhost:2181", error_code, "/testing")};
 }
 
 void NamenodeTest::TearDown() {
-  client->zk->close();
-  zk->close();
 }
 
 hadoop::hdfs::CreateRequestProto NamenodeTest::getCreateRequestProto(
@@ -435,7 +435,7 @@ TEST_F(NamenodeTest, testRenameFile) {
   // Ensure that the renamed node has the same data
   zkclient::FileZNode renamed_data;
   std::vector<std::uint8_t> data(sizeof(renamed_data));
-  ASSERT_TRUE(zk->get("/fileSystem/new_name", data, error_code));
+  ASSERT_TRUE(zk->get("/fileSystem/new_name", data, error_code, false));
   std::uint8_t *buffer = &data[0];
   memcpy(&renamed_data, buffer, sizeof(renamed_data));
   ASSERT_EQ(1, renamed_data.replication);
@@ -445,7 +445,7 @@ TEST_F(NamenodeTest, testRenameFile) {
   // Ensure that the file's child indicating block_id was renamed as well
   auto new_block_data = std::vector<std::uint8_t>();
   zk->get("/fileSystem/new_name/blocks/block-0000000000",
-          new_block_data, error_code);
+          new_block_data, error_code, true);
   ASSERT_EQ(0, error_code);
   ASSERT_EQ("Block uuid",
             std::string(new_block_data.begin(), new_block_data.end()));
@@ -488,19 +488,19 @@ TEST_F(NamenodeTest, testRenameDirWithFiles) {
   // // Ensure that the renamed node has the same data
   zkclient::FileZNode renamed_data;
   std::vector<std::uint8_t> data(sizeof(renamed_data));
-  ASSERT_TRUE(zk->get("/fileSystem/new_dir", data, error_code));
+  ASSERT_TRUE(zk->get("/fileSystem/new_dir", data, error_code, false));
   memcpy(&renamed_data, &data[0], sizeof(renamed_data));
   ASSERT_EQ(0, renamed_data.replication);
   ASSERT_EQ(0, renamed_data.blocksize);
   ASSERT_EQ(1, renamed_data.filetype);
 
-  ASSERT_TRUE(zk->get("/fileSystem/new_dir/file1", data, error_code));
+  ASSERT_TRUE(zk->get("/fileSystem/new_dir/file1", data, error_code, false));
   memcpy(&renamed_data, &data[0], sizeof(renamed_data));
   ASSERT_EQ(1, renamed_data.replication);
   ASSERT_EQ(0, renamed_data.blocksize);
   ASSERT_EQ(2, renamed_data.filetype);
 
-  ASSERT_TRUE(zk->get("/fileSystem/new_dir/file2", data, error_code));
+  ASSERT_TRUE(zk->get("/fileSystem/new_dir/file2", data, error_code, false));
   memcpy(&renamed_data, &data[0], sizeof(renamed_data));
   ASSERT_EQ(1, renamed_data.replication);
   ASSERT_EQ(0, renamed_data.blocksize);
@@ -508,7 +508,8 @@ TEST_F(NamenodeTest, testRenameDirWithFiles) {
 
   ASSERT_TRUE(zk->get("/fileSystem/new_dir/nested_dir/nested_file",
                       data,
-                      error_code));
+                      error_code,
+                      false));
   memcpy(&renamed_data, &data[0], sizeof(renamed_data));
   ASSERT_EQ(1, renamed_data.replication);
   ASSERT_EQ(0, renamed_data.blocksize);

--- a/test/namenode/NameNodeTest.cc
+++ b/test/namenode/NameNodeTest.cc
@@ -14,10 +14,8 @@ void NamenodeTest::SetUp() {
             std::make_shared<ZKWrapper>("localhost:2181",
             error_code, "/testing");
     assert(error_code == 0);  // Z_OK
-    client = std::unique_ptr<zkclient::ZkNnClient>{
-        new zkclient::ZkNnClient(zk_shared)};
-    zk = std::unique_ptr<ZKWrapper>{
-        new ZKWrapper("localhost:2181", error_code, "/testing")};
+    client = new zkclient::ZkNnClient{zk_shared};
+    zk = new ZKWrapper{"localhost:2181", error_code, "/testing"};
 }
 
 void NamenodeTest::TearDown() {

--- a/test/namenode/NameNodeTest.h
+++ b/test/namenode/NameNodeTest.h
@@ -26,8 +26,8 @@ class NamenodeTest : public ::testing::Test {
             const std::string &path);
 
     // Objects declared here can be used by all tests in the test case for Foo.
-    ZKWrapper *zk;
-    zkclient::ZkNnClient *client;
+    std::unique_ptr<ZKWrapper> zk;
+    std::unique_ptr<zkclient::ZkNnClient> client;
 };
 
 #endif  // TEST_NAMENODE_NAMENODETEST_H_

--- a/test/namenode/NameNodeTest.h
+++ b/test/namenode/NameNodeTest.h
@@ -26,8 +26,8 @@ class NamenodeTest : public ::testing::Test {
             const std::string &path);
 
     // Objects declared here can be used by all tests in the test case for Foo.
-    std::unique_ptr<ZKWrapper> zk;
-    std::unique_ptr<zkclient::ZkNnClient> client;
+    ZKWrapper *zk;
+    zkclient::ZkNnClient *client;
 };
 
 #endif  // TEST_NAMENODE_NAMENODETEST_H_

--- a/test/namenode/RenameTest.cc
+++ b/test/namenode/RenameTest.cc
@@ -52,7 +52,7 @@ TEST_F(NamenodeTest, renameBasicFile) {
     // Ensure that the renamed node has the same data
     zkclient::FileZNode renamed_data;
     std::vector<std::uint8_t> data(sizeof(renamed_data));
-    ASSERT_TRUE(zk->get("/fileSystem/renamed_file", data, error_code));
+    ASSERT_TRUE(zk->get("/fileSystem/renamed_file", data, error_code, false));
     std::uint8_t *buffer = &data[0];
     memcpy(&renamed_data, buffer, sizeof(renamed_data));
     ASSERT_EQ(1, renamed_data.replication);
@@ -62,7 +62,7 @@ TEST_F(NamenodeTest, renameBasicFile) {
     // Ensure that the file's child indicating block_id was renamed as well
     auto new_block_data = std::vector<std::uint8_t>();
     zk->get("/fileSystem/renamed_file/blocks/block-0000000000",
-    new_block_data, error_code);
+    new_block_data, error_code, true);
     ASSERT_EQ(0, error_code);
     ASSERT_EQ("Block uuid",
     std::string(new_block_data.begin(), new_block_data.end()));

--- a/test/zkwrapper/ZKLockTest.cc
+++ b/test/zkwrapper/ZKLockTest.cc
@@ -18,7 +18,7 @@ class ZKLockTest : public ::testing::Test {
     // Code here will be called immediately after the constructor (right
     // before each test).
     int errorCode;
-    zkWrapper = new ZKWrapper("localhost:2181", errorCode, "/testing");
+    zkWrapper = new ZKWrapper("localhost:2181", errorCode, "");
     assert(errorCode == 0);  // ZOK
   }
 

--- a/test/zkwrapper/ZKLockTest.cc
+++ b/test/zkwrapper/ZKLockTest.cc
@@ -18,7 +18,7 @@ class ZKLockTest : public ::testing::Test {
     // Code here will be called immediately after the constructor (right
     // before each test).
     int errorCode;
-    zkWrapper = new ZKWrapper("localhost:2181", errorCode);
+    zkWrapper = new ZKWrapper("localhost:2181", errorCode, "/testing");
     assert(errorCode == 0);  // ZOK
   }
 

--- a/test/zkwrapper/ZKWrapperTest.cc
+++ b/test/zkwrapper/ZKWrapperTest.cc
@@ -88,10 +88,10 @@ TEST_F(ZKWrapperTest, recursive_create) {
   auto data = ZKWrapper::get_byte_vector("hello");
   result = zk->recursive_create("/testrecur/test2", data, error);
   ASSERT_EQ(true, result);
-  result = zk->get("/testrecur/test2", retrieved_data, error);
+  result = zk->get("/testrecur/test2", retrieved_data, error, true);
   ASSERT_EQ(true, result);
   ASSERT_EQ(5, retrieved_data.size());
-  result = zk->get("/testrecur", retrieved_data, error);
+  result = zk->get("/testrecur", retrieved_data, error, true);
   ASSERT_EQ(true, result);
   ASSERT_EQ(0, retrieved_data.size());
 
@@ -197,7 +197,7 @@ TEST_F(ZKWrapperTest, get) {
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
   std::vector<std::uint8_t> data(65536);
-  result = zk->get("/testget", data, error);
+  result = zk->get("/testget", data, error, true);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
   ASSERT_EQ(0, data.size());
@@ -209,7 +209,7 @@ TEST_F(ZKWrapperTest, get) {
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
   std::vector<std::uint8_t> retrieved_data(65536);
-  result = zk->get("/testget_withdata", retrieved_data, error);
+  result = zk->get("/testget_withdata", retrieved_data, error, true);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
   ASSERT_EQ(5, retrieved_data.size());
@@ -223,7 +223,7 @@ TEST_F(ZKWrapperTest, wget) {
 
   std::vector<std::uint8_t> data(65536);
   bool check = false;
-  result = zk->wget("/testwget1", data, test_watcher, &check, error);
+  result = zk->wget("/testwget1", data, test_watcher, &check, error, false);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
   ASSERT_EQ(0, data.size());
@@ -256,7 +256,7 @@ TEST_F(ZKWrapperTest, set) {
   ASSERT_EQ("ZOK", zk->translate_error(error));
 
   std::vector<std::uint8_t> data_get(65536);
-  result = zk->get("/testget1", data_get, error);
+  result = zk->get("/testget1", data_get, error, true);
   ASSERT_EQ(true, result);
   ASSERT_EQ("ZOK", zk->translate_error(error));
   ASSERT_EQ(5, data_get.size());
@@ -318,11 +318,11 @@ TEST_F(ZKWrapperTest, MultiOperation) {
 
   std::vector<std::uint8_t> vec = std::vector<std::uint8_t>();
 
-  zk->get("/child11", vec, error_code);
+  zk->get("/child11", vec, error_code, true);
   ASSERT_EQ(hello_vec, vec);
-  zk->get("/child21", vec, error_code);
+  zk->get("/child21", vec, error_code, true);
   ASSERT_EQ(jello_vec, vec);
-  zk->get("/toDelete1", vec, error_code);
+  zk->get("/toDelete1", vec, error_code, true);
   ASSERT_EQ(bye_vec, vec);
 
   auto nhello_vec = ZKWrapper::get_byte_vector("new_hello");
@@ -339,9 +339,9 @@ TEST_F(ZKWrapperTest, MultiOperation) {
 
   ASSERT_TRUE(zk->execute_multi(operations, results, error_code));
 
-  zk->get("/child11", vec, error_code);
+  zk->get("/child11", vec, error_code, true);
   ASSERT_EQ(nhello_vec, vec);
-  zk->get("/child21", vec, error_code);
+  zk->get("/child21", vec, error_code, true);
   ASSERT_EQ(njello_vec, vec);
 
   bool exists;

--- a/test/zookeeper/zk_dn_client_test.cc
+++ b/test/zookeeper/zk_dn_client_test.cc
@@ -66,7 +66,7 @@ TEST_F(ZKDNClientTest, CanReadBlockSize) {
 
   client->blockReceived(block_id, block_size);
 
-  ASSERT_TRUE(zk->get(path, data, error_code));
+  ASSERT_TRUE(zk->get(path, data, error_code, false));
   memcpy(&size, &data[0], sizeof(data));
   ASSERT_EQ(block_size, size);
 }
@@ -82,7 +82,7 @@ TEST_F(ZKDNClientTest, CanDeleteBlock) {
   zk->create(path, ZKWrapper::EMPTY_VECTOR, error_code, false);
 
   client->blockReceived(block_id, block_size);
-  ASSERT_TRUE(zk->get(path + "/" + dn_id, data, error_code));
+  ASSERT_TRUE(zk->get(path + "/" + dn_id, data, error_code, false));
 }
 
 int main(int argc, char **argv) {

--- a/zkwrapper/include/zk_lock.h
+++ b/zkwrapper/include/zk_lock.h
@@ -25,6 +25,10 @@ class ZKLock {
    * @param zkWrapper
    * @param path the path to lock onto. This path does not need to exist inside ZooKeeper.
    * @return
+   *
+   * TODO(2017) What exactly do we need here in terms of cloning zkWrapper?
+   * Default copying causes problem for resource reclamation (risking leakage
+   * or double free).
    */
   ZKLock(ZKWrapper &zkWrapper, std::string path) :
           zkWrapper(zkWrapper), path_to_lock(path) {}

--- a/zkwrapper/source/zkwrapper.cc
+++ b/zkwrapper/source/zkwrapper.cc
@@ -226,7 +226,15 @@ ZKWrapper::~ZKWrapper() {
      * we risk double freeing due to zkWrapper being potentially copied in
      * zk_lock. See the TODO in zk_lock.h
      */
-    close();
+    /*
+     * TODO(2017) We would do "close();" here, but ZKWrapper cloning is again
+     * causing issues.
+     * One way to convince yourself that "close();" is being properly called is
+     * to reduce the max number of connections that ZooKeeper accepts and see
+     * if all the unit tests still pass. The "maxClientCnxns" configuration
+     * option can be changed to achieve this. We had to bump this number since
+     * connections are not being properly reclaimed.
+     */
 }
 
 std::string ZKWrapper::prepend_zk_root(const std::string &path) const {

--- a/zkwrapper/source/zkwrapper.cc
+++ b/zkwrapper/source/zkwrapper.cc
@@ -5,42 +5,19 @@
 #include <condition_variable>
 #include <thread>
 
-int init = 0;
-zhandle_t *zh;
-clientid_t myid;
-
 const std::vector<std::uint8_t>
     ZKWrapper::EMPTY_VECTOR = std::vector<std::uint8_t>(0);
 
-const std::map<int, std::string> ZKWrapper::error_message = {
-    {0, "ZOK"},
-    {-1, "ZSYSTEMERROR"},
-    {-2, "ZRUNTIMEINCONSISTENCY"},
-    {-3, "ZDATAINCONSISTENCY"},
-    {-4, "ZCONNECTIONLOSS"},
-    {-5, "ZMARSHALLINGERROR"},
-    {-6, "ZUNIMPLEMENTED"},
-    {-7, "ZOPERATIONTIMEOUT"},
-    {-8, "ZBADARGUMENTS"},
-    {-9, "ZINVALIDSTATE"},
-    {-100, "ZAPIERROR"},
-    {-101, "ZNONODE"},
-    {-102, "ZNOAUTH"},
-    {-103, "ZBADVERSION"},
-    {-108, "ZNOCHILDRENFOREPHEMERALS"},
-    {-110, "ZNODEEXISTS"},
-    {-111, "ZNOTEMPTY"},
-    {-112, "ZSESSIONEXPIRED"},
-    {-113, "ZINVALIDCALLBACK"},
-    {-114, "ZINVALIDACL"},
-    {-115, "ZAUTHFAILED"},
-    {-116, "ZCLOSING"},
-    {-117, "ZNOTHING"},
-    {-118, "ZSESSIONMOVED"},
-    {-120, "ZNEWCONFIGNOQUORUM"},
-    {-121, "ZRECONFIGINPROGRESS"},
-    {-999, "ZKWRAPPERDEFAULTERROR"},
-};
+const int ZKWrapper::MAX_PAYLOAD = 65536;
+const int ZKWrapper::MAX_PATH_LEN = 512;
+const int ZKWrapper::NUM_SEQUENTIAL_DIGITS = 10;
+const int ZKWrapper::DEFAULT_ZK_RECV_TIMEOUT = 10000;
+const int ZKWrapper::INITIAL_CONNECTION_TIMEOUT_MILLIS = 20000;
+const int ZKWrapper::INITIAL_CONNECTION_RETRY_INTERVAL_MILLIS = 2500;
+const int ZKWrapper::ROOT_CREATION_RETRY_LIMIT = 5;
+const int ZKWrapper::ROOT_CREATION_RETRY_INTERVAL_MILLIS = 2500;
+
+/* TODO(2017) most of the shared_ptr's can be replaced by unique_ptr's. */
 
 /**
  * Currently watches the zookeeper handle and closes zookeeper on
@@ -57,9 +34,13 @@ void watcher(zhandle_t *zzh,
        int state,
        const char *path,
        void *watcherCtx) {
-  LOG(INFO) << "[Global watcher] Watcher triggered on path '" << path << "'";
+  LOG(INFO) << "[Global watcher] Watcher triggered on path '" << path << "'"
+            << " with type " << ZKWrapper::translate_watch_event_type(type)
+            << " and state " << ZKWrapper::translate_watch_state(state);
   if (type == ZOO_SESSION_EVENT) {
     if (state == ZOO_CONNECTED_STATE) {
+      auto zkWrapper = reinterpret_cast<ZKWrapper *>(watcherCtx);
+      zkWrapper->connected = true;
       return;
     } else if (state == ZOO_AUTH_FAILED_STATE) {
       zookeeper_close(zzh);
@@ -69,6 +50,7 @@ void watcher(zhandle_t *zzh,
       exit(1);
     }
   }
+  LOG(INFO) << "[Global watcher] Falling through and doing nothing";
 }
 
 void ZKWrapper::watcher_znode_data(zhandle_t *zzh,
@@ -76,7 +58,9 @@ void ZKWrapper::watcher_znode_data(zhandle_t *zzh,
             int state,
             const char *path,
             void *watcherCtx) {
-  LOG(INFO) << "Watcher triggered on path '" << path << "'";
+  LOG(INFO) << "[Znode watcher] Watcher triggered on path '" << path << "'"
+            << " with type " << ZKWrapper::translate_watch_event_type(type)
+            << " and state " << ZKWrapper::translate_watch_state(state);
 
   auto zkWrapper = reinterpret_cast<ZKWrapper *>(watcherCtx);
   auto src = zkWrapper->removeZKRootAndDir(zkWrapper->root + "/fileSystem",
@@ -85,61 +69,168 @@ void ZKWrapper::watcher_znode_data(zhandle_t *zzh,
 }
 
 std::string ZKWrapper::translate_error(int errorcode) {
-  std::string message;
-  message = error_message.at(errorcode);
-  return message;
+  static const std::map<int, std::string> ERROR_MESSAGES = {
+          {0,    "ZOK"},
+          {-1,   "ZSYSTEMERROR"},
+          {-2,   "ZRUNTIMEINCONSISTENCY"},
+          {-3,   "ZDATAINCONSISTENCY"},
+          {-4,   "ZCONNECTIONLOSS"},
+          {-5,   "ZMARSHALLINGERROR"},
+          {-6,   "ZUNIMPLEMENTED"},
+          {-7,   "ZOPERATIONTIMEOUT"},
+          {-8,   "ZBADARGUMENTS"},
+          {-9,   "ZINVALIDSTATE"},
+          {-100, "ZAPIERROR"},
+          {-101, "ZNONODE"},
+          {-102, "ZNOAUTH"},
+          {-103, "ZBADVERSION"},
+          {-108, "ZNOCHILDRENFOREPHEMERALS"},
+          {-110, "ZNODEEXISTS"},
+          {-111, "ZNOTEMPTY"},
+          {-112, "ZSESSIONEXPIRED"},
+          {-113, "ZINVALIDCALLBACK"},
+          {-114, "ZINVALIDACL"},
+          {-115, "ZAUTHFAILED"},
+          {-116, "ZCLOSING"},
+          {-117, "ZNOTHING"},
+          {-118, "ZSESSIONMOVED"},
+          {-120, "ZNEWCONFIGNOQUORUM"},
+          {-121, "ZRECONFIGINPROGRESS"},
+          {-997, "ZKWRAPPERINSUFFICIENTBUFFER"},
+          {-998, "ZKWRAPPERUNINITIALIZED"},
+          {-999, "ZKWRAPPERDEFAULTERROR"},
+  };
+  try {
+    return ERROR_MESSAGES.at(errorcode);
+  } catch (const std::out_of_range&) {
+    return "Unknown error code " + std::to_string(errorcode);
+  }
 }
 
-ZKWrapper::ZKWrapper(std::string host,
-                     int &error_code,
-                     std::string root_path) {
-  // TODO(2016): Move these default values to some readable CONSTANT value
-  zh = zookeeper_init(host.c_str(), watcher, 10000, 0, 0, 0);
-  cache = new lru::Cache<std::string,
-                         std::shared_ptr<std::vector<unsigned char>>>(512, 10);
-
-  if (!zh) {
-    LOG(ERROR) << "zk init failed!";
-    error_code = -999;
+std::string ZKWrapper::translate_watch_event_type(int type) {
+  static const std::map<int, std::string> WATCH_EVENT_TYPE = {
+          {ZOO_CREATED_EVENT,     "ZOO_CREATED_EVENT"},
+          {ZOO_DELETED_EVENT,     "ZOO_DELETED_EVENT"},
+          {ZOO_CHANGED_EVENT,     "ZOO_CHANGED_EVENT"},
+          {ZOO_CHILD_EVENT,       "ZOO_CHILD_EVENT"},
+          {ZOO_SESSION_EVENT,     "ZOO_SESSION_EVENT"},
+          {ZOO_NOTWATCHING_EVENT, "ZOO_NOTWATCHING_EVENT"}
+  };
+  try {
+    return WATCH_EVENT_TYPE.at(type);
+  } catch (const std::out_of_range&) {
+    return "Unknown type " + std::to_string(type);
   }
-  init = 1;
-  if (root_path.size() != 0) {
+}
+
+std::string ZKWrapper::translate_watch_state(int state) {
+  static const std::map<int, std::string> WATCH_STATE = {
+          {ZOO_EXPIRED_SESSION_STATE, "ZOO_EXPIRED_SESSION_STATE"},
+          {ZOO_AUTH_FAILED_STATE,     "ZOO_AUTH_FAILED_STATE"},
+          {ZOO_CONNECTING_STATE,      "ZOO_CONNECTING_STATE"},
+          {ZOO_ASSOCIATING_STATE,     "ZOO_ASSOCIATING_STATE"},
+          {ZOO_CONNECTED_STATE,       "ZOO_CONNECTED_STATE"}
+  };
+  try {
+    return WATCH_STATE.at(state);
+  } catch (const std::out_of_range&) {
+    return "Unknown state " + std::to_string(state);
+  }
+}
+
+ZKWrapper::ZKWrapper(const std::string &host,
+                     int &error_code,
+                     const std::string &root_path) {
+  zh = zookeeper_init(host.c_str(), watcher, DEFAULT_ZK_RECV_TIMEOUT,
+                      nullptr, this, 0);
+  if (!zh) {
+    LOG(ERROR) << "zookeeper_init failed!";
+    error_code = ZKWRAPPERDEFAULTERROR;
+    initializing = false;
+    return;
+  }
+
+  for (int j = 0; !connected && j < INITIAL_CONNECTION_TIMEOUT_MILLIS;
+       j += INITIAL_CONNECTION_RETRY_INTERVAL_MILLIS) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(
+            INITIAL_CONNECTION_RETRY_INTERVAL_MILLIS));
+  }
+  if (!connected) {
+    LOG(ERROR) << "[zkwrapper] initial connection timed out";
+    error_code = ZKWRAPPERDEFAULTERROR;
+    initializing = false;
+    return;
+  }
+
+  if (!root_path.empty()) {
     bool root_exists = false;
-    while (!root_exists) {
+    int i;
+    for (i = 0; i < ROOT_CREATION_RETRY_LIMIT && !root_exists; ++i,
+            std::this_thread::sleep_for(std::chrono::milliseconds(
+                    ROOT_CREATION_RETRY_INTERVAL_MILLIS))) {
       if (!exists(root_path, root_exists, error_code)) {
         LOG(ERROR) << "Failed to check if root directory "
-               << root
-               << " exists "
-               << error_code;
+                   << root
+                   << " exists "
+                   << error_code;
+        continue;
+      } else {
+        break;
       }
-      if (!root_exists) {
+    }
+    if (i == ROOT_CREATION_RETRY_LIMIT) {
+      LOG(ERROR) << "Reached retry limit of "
+                 << std::to_string(ROOT_CREATION_RETRY_LIMIT)
+                 << " trying to test existence of root " << root_path;
+      error_code = ZKWRAPPERDEFAULTERROR;
+      initializing = false;
+      return;
+    }
+    if (!root_exists) {
+      for (i = 0; i < ROOT_CREATION_RETRY_LIMIT; ++i,
+              std::this_thread::sleep_for(std::chrono::milliseconds(
+                      ROOT_CREATION_RETRY_INTERVAL_MILLIS))) {
         if (!recursive_create(root_path, EMPTY_VECTOR, error_code)) {
           LOG(ERROR) << "Failed to create root directory "
-                 << root
-                 << " with error "
-                 << error_code;
+                     << root
+                     << " with error "
+                     << error_code;
         } else {
           root_exists = true;
           break;
         }
       }
-    }
-
-    if (!root_exists) {
-      if (!recursive_create(root_path, EMPTY_VECTOR, error_code)) {
-        LOG(ERROR) << "Failed to create root directory "
-               << root
-               << " with error "
-               << error_code;
+      if (i == ROOT_CREATION_RETRY_LIMIT) {
+        LOG(ERROR) << "Reached retry limit of "
+                   << std::to_string(ROOT_CREATION_RETRY_LIMIT)
+                   << " trying to create root " << root_path;
+        error_code = ZKWRAPPERDEFAULTERROR;
+        initializing = false;
+        return;
       }
     }
+    root = root_path;
   }
-  LOG(INFO) << "SUCCESSFULLY STARTED ZKWRAPPER";
-  root = root_path;
+
+  cache = new lru::Cache<std::string,
+      std::shared_ptr<std::vector<unsigned char>>>(512, 10);
+  initialized = true;
+  initializing = false;
+  error_code = ZOK;
+  LOG(INFO) << "SUCCESSFULLY INITIALIZED ZKWRAPPER";
+}
+
+ZKWrapper::~ZKWrapper() {
+    /*
+     * TODO(2017) We would do "delete cache;" here, except for the fact that
+     * we risk double freeing due to zkWrapper being potentially copied in
+     * zk_lock. See the TODO in zk_lock.h
+     */
+    close();
 }
 
 std::string ZKWrapper::prepend_zk_root(const std::string &path) const {
-  if (root.size() == 0) {
+  if (root.empty()) {
     return path;
   }
   if (path == "/") {
@@ -174,9 +265,9 @@ bool ZKWrapper::create(const std::string &path,
              int &error_code,
              bool ephemeral,
              bool sync) const {
-  if (!init) {
+  if (!initialized && !initializing) {
     LOG(ERROR) << "Attempt to create before init!";
-    error_code = -999;
+    error_code = ZKWRAPPERUNINITIALIZED;
     return false;
   }
   auto real_path = prepend_zk_root(path);
@@ -185,7 +276,7 @@ bool ZKWrapper::create(const std::string &path,
   int rc = zoo_create(zh,
             real_path.c_str(),
             reinterpret_cast<const char *>(data.data()),
-            data.size(),
+            static_cast<int>(data.size()),
             &ZOO_OPEN_ACL_UNSAFE,
             flag,
             nullptr,
@@ -210,11 +301,12 @@ bool ZKWrapper::create_sequential(const std::string &path,
                   bool ephemeral,
                   int &error_code,
                   bool sync) const {
-  LOG(INFO) << "Starting sequential for " << path;
-  if (!init) {
-    LOG(ERROR) << "Attempt to create sequential before init!";
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
     return false;
   }
+  LOG(INFO) << "Starting sequential for " << path;
   int flag = ZOO_SEQUENCE;
   if (ephemeral) {
     flag = flag | ZOO_EPHEMERAL;
@@ -222,27 +314,26 @@ bool ZKWrapper::create_sequential(const std::string &path,
   LOG(INFO) << "Attempting to generate new path" << new_path;
   LOG(INFO) << "Creating seq ZNode at " << prepend_zk_root(path);
 
-  int len = prepend_zk_root(path).size();
-  new_path.resize(MAX_PATH_LEN);
+  auto len = prepend_zk_root(path).size();
+  new_path.resize(static_cast<size_t>(MAX_PATH_LEN));
   int rc = zoo_create(zh,
             prepend_zk_root(path).c_str(),
             reinterpret_cast<const char *>(data.data()),
-            data.size(),
+            static_cast<int>(data.size()),
             &ZOO_OPEN_ACL_UNSAFE,
             flag,
-            reinterpret_cast<char *>(&new_path[0]),
+            &new_path[0],
             MAX_PATH_LEN);
   error_code = rc;
-  if (rc) {  // Z_OK is 0, so if we receive anything else fail
+  if (rc != ZOK) {  // Z_OK is 0, so if we receive anything else fail
     LOG(ERROR) << "Create for " << prepend_zk_root(path) << " failed " << rc;
     print_error(error_code);
     return false;
   }
-  int i = 0;
   LOG(INFO) << "NEW path is " << new_path;
   new_path.resize(len + NUM_SEQUENTIAL_DIGITS);
 
-  if (sync && !rc) {
+  if (sync) {
     flush(new_path);
   }
 
@@ -256,9 +347,14 @@ bool ZKWrapper::recursive_create(const std::string &path,
                  const std::vector<std::uint8_t> &data,
                  int &error_code,
                  bool sync) const {
-  for (int i = 1; i < path.length(); ++i) {
+  if (!initialized && !initializing) {
+    LOG(ERROR) << "Attempt to recursive_create before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  for (std::size_t i = 1; i < path.length(); ++i) {
     if (path[i] == '/') {
-      LOG(INFO) << "Generating " << path.substr(0, i);
+      LOG(INFO) << "Creating " << path.substr(0, i);
       if (!create(path.substr(0, i),
             ZKWrapper::EMPTY_VECTOR,
             error_code,
@@ -282,12 +378,26 @@ bool ZKWrapper::wget(const std::string &path,
            watcher_fn watch,
            void *watcherCtx,
            int &error_code,
-           int length) const {
-  // TODO(2016): Make this a constant value.
-  // Define a smarter retry policy for oversized data
-  int len = length;
-  data.resize(len);
-  struct Stat stat;
+           bool resize) const {
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  auto len = static_cast<int>(data.size());
+  struct Stat stat{};
+  if (data.empty() && resize) {
+    /*
+     * The caller didn't bother to allocate a non-trivial buffer, so we do it
+     * here to prevent the first get operation from being pointless.
+     *
+     * The 2016 folks claim that MAX_PAYLOAD is a sane default size.
+     * We (2017) have no idea why.
+     */
+    len = MAX_PAYLOAD;
+    data.resize(static_cast<uint64_t>(len));
+  }
+RETRY_WGET:
   error_code = zoo_wget(zh,
               prepend_zk_root(path).c_str(),
               watch,
@@ -295,51 +405,65 @@ bool ZKWrapper::wget(const std::string &path,
               reinterpret_cast<char *>(data.data()),
               &len,
               &stat);
-  if (error_code != ZOK) {
+  if (error_code == ZOK) {
+    if (len < stat.dataLength && resize) {
+      len = stat.dataLength;
+      data.resize(static_cast<uint64_t>(stat.dataLength));
+      resize = false;
+      goto RETRY_WGET;
+    }
+    if (len < stat.dataLength) {
+      /* The data didn't fit in the buffer. */
+      LOG(ERROR) << "node data larger than buffer";
+      error_code = ZKWRAPPERINSUFFICIENTBUFFER;
+      return false;
+    } else {
+      data.resize(static_cast<uint64_t>(len));
+      /*
+       * TODO(2017) How does zookeeper distinguish different watches? It seems
+       * capable of handling multiple watches on a single znode, but what is
+       * the criteria for uniqueness? For now, just assume that the watcher
+       * that's supposed to invalidate the cache is being overwritten, so we
+       * need to invalidate cache here to prevent stale values from lingering
+       * around in the cache forever.
+       */
+      cache->remove(path);
+    }
+  } else {
     LOG(ERROR) << "wget on " << path << " failed";
     print_error(error_code);
     return false;
   }
-  data.resize(len);
+  data.resize(static_cast<std::size_t>(len));
   return true;
 }
 
 bool ZKWrapper::get(const std::string &path,
           std::vector<std::uint8_t> &data,
           int &error_code,
-          int length) const {
-  // TODO(2016): Make this a constant value.
-  // Define a smarter retry policy for oversized data
-  struct Stat stat;
-  int len = length;
-  // TODO(2016): Perhaps we can be smarter about this
-  data.resize(len);
-    LOG(INFO) << "Get on path " << path << " in ZkWrapper";
+          bool resize) const {
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  LOG(INFO) << "Get on path " << path << " in ZkWrapper";
 
   if (cache->contains(path)) {
     LOG(INFO) << "Found path " << path << " in ZkWrapper cache";
     auto cached_data = cache->get(path);
-        std::vector<std::uint8_t> *cached = cached_data.get();
-        data = *cached;
-
+    data = *cached_data.get();
   } else {
-    error_code = zoo_wget(zh,
-                prepend_zk_root(path).c_str(),
-                watcher_znode_data,
-                const_cast<ZKWrapper *>(this),
-                reinterpret_cast<char *>(data.data()),
-                &len,
-                &stat);
-        std::shared_ptr<std::vector<std::uint8_t>> data_copy =
-                std::make_shared<std::vector<unsigned char>> (data);
-        cache->insert(path, data_copy);
-        if (error_code != ZOK) {
-            LOG(ERROR) << "get on " << path << " failed";
-            print_error(error_code);
-            return false;
-        }
+    if (wget(path, data, watcher_znode_data, const_cast<ZKWrapper *>(this),
+             error_code, resize)) {
+      auto data_copy = std::make_shared<std::vector<uint8_t>>(data);
+      cache->insert(path, data_copy);
+    } else {
+      LOG(ERROR) << "get on " << path << " failed";
+      print_error(error_code);
+      return false;
+    }
   }
-  data.resize(len);
   return true;
 }
 
@@ -348,10 +472,15 @@ bool ZKWrapper::set(const std::string &path,
           int &error_code,
           bool sync,
           int version) const {
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
   error_code = zoo_set(zh,
              prepend_zk_root(path).c_str(),
              reinterpret_cast<const char *>(data.data()),
-             data.size(),
+             static_cast<int>(data.size()),
              version);
     cache->remove(path);
 
@@ -371,8 +500,12 @@ bool ZKWrapper::set(const std::string &path,
 bool ZKWrapper::exists(const std::string &path,
              bool &exist,
              int &error_code) const {
-  // TODO(2016): for now watch argument is set to 0, need more error checking
-  int rc = zoo_exists(zh, prepend_zk_root(path).c_str(), 0, 0);
+  if (!initialized && !initializing) {
+    LOG(ERROR) << "Attempt to exists before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  int rc = zoo_exists(zh, prepend_zk_root(path).c_str(), 0, nullptr);
   error_code = rc;
   if (rc == ZOK) {
     exist = true;
@@ -393,7 +526,12 @@ bool ZKWrapper::wexists(const std::string &path,
             watcher_fn watch,
             void *watcherCtx,
             int &error_code) const {
-  struct Stat stat;
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  struct Stat stat{};
   int rc = zoo_wexists(zh,
              prepend_zk_root(path).c_str(),
              watch,
@@ -416,7 +554,12 @@ bool ZKWrapper::wexists(const std::string &path,
 bool ZKWrapper::delete_node(const std::string &path,
               int &error_code,
               bool sync) const {
-  // NOTE: use -1 for version, check will not take place.
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  /* Use -1 for version to delete the node regardless of its version. */
   error_code = zoo_delete(zh, prepend_zk_root(path).c_str(), -1);
   if (error_code != ZOK) {
     LOG(ERROR) << "delete on " << path << " failed";
@@ -424,8 +567,7 @@ bool ZKWrapper::delete_node(const std::string &path,
     return false;
   }
 
-  // TODO(2016)
-  if (sync && !error_code) {
+  if (sync) {
     flush(prepend_zk_root(path));
   }
   return true;
@@ -434,9 +576,14 @@ bool ZKWrapper::delete_node(const std::string &path,
 bool ZKWrapper::get_info(const std::string &path,
              struct Stat &stat,
              int &error_code) const {
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
   std::vector<std::uint8_t> data;
-  int len = MAX_PAYLOAD;
-  data.resize(len);
+  auto len = MAX_PAYLOAD;
+  data.resize(static_cast<std::size_t>(len));
 
   error_code = zoo_get(zh,
              prepend_zk_root(path).c_str(),
@@ -449,13 +596,18 @@ bool ZKWrapper::get_info(const std::string &path,
     print_error(error_code);
     return false;
   }
-  data.resize(len);
+  data.resize(static_cast<std::size_t>(len));
   return true;
 }
 
 // TODO(2016): Modify
 bool ZKWrapper::recursive_delete(const std::string &path,
                  int &error_code) const {
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
   LOG(INFO) << "Recursively deleting " << path;
   bool root = ("/" == path);
   bool endsSlash = path[path.size() - 1] == '/';
@@ -470,12 +622,13 @@ bool ZKWrapper::recursive_delete(const std::string &path,
     return false;
   }
 
-  for (auto child : children) {
+  for (const auto &child : children) {
     LOG(INFO) << "child is " << child;
-    if (child.size() == 0) {
+    if (child.empty()) {
       continue;
     }
-    std::string newPath = znodePath + "/" + child;
+    std::string newPath = znodePath;
+    newPath.append("/").append(child);
     int result = recursive_delete(newPath, error_code);
     rc = (result != 0) ? result : rc;
   }
@@ -493,17 +646,22 @@ bool ZKWrapper::recursive_delete(const std::string &path,
 bool ZKWrapper::get_children(const std::string &path,
                std::vector<std::string> &children,
                int &error_code) const {
-  struct String_vector stvector;
-  struct String_vector *vector = &stvector;
-  error_code = zoo_get_children(zh, prepend_zk_root(path).c_str(), 0, vector);
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  struct String_vector stvector{};
+  error_code = zoo_get_children(zh, prepend_zk_root(path).c_str(),
+                                0, &stvector);
   if (error_code != ZOK) {
     LOG(ERROR) << "get_children on " << path << " failed";
     print_error(error_code);
     return false;
   }
-  int i;
-  for (i = 0; i < stvector.count; i++) {
-    children.push_back(stvector.data[i]);
+
+  for (int i = 0; i < stvector.count; i++) {
+    children.emplace_back(stvector.data[i]);
   }
   return true;
 }
@@ -513,22 +671,25 @@ bool ZKWrapper::wget_children(const std::string &path,
                 watcher_fn watch,
                 void *watcherCtx,
                 int &error_code) const {
-  struct String_vector stvector;
-  struct String_vector *vector = &stvector;
+  if (!initialized) {
+    LOG(ERROR) << "Attempt to " << __func__ << " before init!";
+    error_code = ZKWRAPPERUNINITIALIZED;
+    return false;
+  }
+  struct String_vector stvector{};
   error_code = zoo_wget_children(zh,
                    prepend_zk_root(path).c_str(),
                    watch,
                    watcherCtx,
-                   vector);
+                   &stvector);
   if (error_code != ZOK) {
     LOG(ERROR) << "wget_children on " << path << " failed";
     print_error(error_code);
     return false;
   }
 
-  int i;
-  for (i = 0; i < stvector.count; i++) {
-    children.push_back(stvector.data[i]);
+  for (int i = 0; i < stvector.count; i++) {
+    children.emplace_back(stvector.data[i]);
   }
   return true;
 }
@@ -579,17 +740,18 @@ bool ZKWrapper::execute_multi(const std::vector<std::shared_ptr<ZooOp>> ops,
                 bool sync) const {
   std::vector<zoo_op_t> trueOps = std::vector<zoo_op_t>();
   results.resize(ops.size());
-  for (auto op : ops) {
+  for (const auto &op : ops) {
     trueOps.push_back(*(op->op));
   }
-  error_code = zoo_multi(zh, ops.size(), &trueOps[0], &results[0]);
+  error_code = zoo_multi(zh, static_cast<int>(ops.size()),
+                         &trueOps[0], &results[0]);
   if (error_code != ZOK) {
     LOG(ERROR) << "multiop failed";
     print_error(error_code);
     return false;
   }
 
-  if (sync && !error_code) {
+  if (sync) {
     flush(root);
   }
   return true;
@@ -601,7 +763,10 @@ std::vector<uint8_t> ZKWrapper::get_byte_vector(const std::string &string) {
 }
 
 void ZKWrapper::close() {
-  zookeeper_close(zh);
+    if (connected) {
+        zookeeper_close(zh);
+        connected = false;
+    }
 }
 
 bool ZKWrapper::flush(const std::string &full_path, bool synchronous) const {
@@ -609,13 +774,13 @@ bool ZKWrapper::flush(const std::string &full_path, bool synchronous) const {
   if (synchronous) {
     // I tried using condition variables,
     // but it ended up failing on occasion, so sadly I resort to polling :(
-    bool *flag = reinterpret_cast<bool *>(malloc(sizeof(bool)));
+    auto flag = reinterpret_cast<bool *>(malloc(sizeof(bool)));
 
     // Lambda to call on function completion
     string_completion_t completion = [](int rc,
                       const char *value,
                       const void *data) {
-      bool *flag_ptr = const_cast<bool *>(reinterpret_cast<const bool *>(data));
+      auto flag_ptr = const_cast<bool *>(reinterpret_cast<const bool *>(data));
       *flag_ptr = true;
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
       free(flag_ptr);
@@ -643,6 +808,6 @@ bool ZKWrapper::flush(const std::string &full_path, bool synchronous) const {
     return true;
   } else {
     auto no_op = [&](int rc, const char *value, const void *data) {};
-    return zoo_async(zh, full_path.c_str(), no_op, nullptr);
+    return zoo_async(zh, full_path.c_str(), no_op, nullptr) == ZOK;
   }
 }

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -799,6 +799,7 @@ class ZkNnClient : public ZkClientCommon {
   const uint64_t EXPIRATION_TIME =
     2 * 60 * 60 * 1000;  // 2 hours in milliseconds.
 
+  /* TODO(2017) This needs to be reclaimed properly. */
   lru::Cache<std::string, std::shared_ptr<GetListingResponseProto>> *cache;
 };
 

--- a/zookeeper/include/zk_nn_client.h
+++ b/zookeeper/include/zk_nn_client.h
@@ -166,6 +166,10 @@ class ZkNnClient : public ZkClientCommon {
   const char* DEFAULT_EC_CODEC_NAME = "rs";
   std::string DEFAULT_STORAGE_ID = "1";  // the default storage id.
   std::string REPLICATION_STORAGE_ID = "63";
+  /*
+   * TODO(2017) For some reason, these fields can't be properly
+   * reclaimed/destructed in some cases.
+   */
   ECSchemaProto DEFAULT_EC_SCHEMA;
   ErasureCodingPolicyProto RS_SOLOMON_PROTO;
   ErasureCodingPolicyProto REPLICATION_PROTO;

--- a/zookeeper/source/zk_dn_client.cc
+++ b/zookeeper/source/zk_dn_client.cc
@@ -416,7 +416,7 @@ bool ZkClientDn::handleReconstructCmds(const std::string &path) {
       DataNodePayload dn_target_info;
       std::vector<std::uint8_t> dn_data(sizeof(DataNodePayload));
       if (!zk->get(HEALTH_BACKSLASH + node.second + STATS, dn_data, err,
-                   sizeof(DataNodePayload))) {
+                   false)) {
         LOG(ERROR) << "failed to read target dn payload" << err;
         continue;
       }
@@ -525,7 +525,7 @@ void ZkClientDn::handleReplicateCmds(const std::string &path) {
     std::vector<std::uint8_t> block_size_vec(sizeof(std::uint64_t));
     std::uint64_t block_size;
     if (!zk->get(get_block_metadata_path(block_id), block_size_vec,
-                 err, sizeof(std::uint64_t))) {
+                 err, false)) {
       LOG(ERROR) << "could not get the block length for "
                  << block
                  << " because of "
@@ -552,7 +552,7 @@ void ZkClientDn::handleReplicateCmds(const std::string &path) {
       DataNodePayload dn_target_info;
       std::vector<std::uint8_t> dn_data(sizeof(DataNodePayload));
       if (!zk->get(HEALTH_BACKSLASH + read_from + STATS, dn_data, err,
-                   sizeof(DataNodePayload))) {
+                   false)) {
         LOG(ERROR) << "failed to read target dn payload" << err;
         continue;
       }
@@ -604,7 +604,7 @@ void ZkClientDn::processDeleteQueue() {
     std::vector<std::uint8_t> block_id_vec(sizeof(std::uint64_t));
     std::uint64_t block_id;
     if (!zk->get(util::concat_path(path, block), block_id_vec, err,
-                 sizeof(std::uint64_t))) {
+                 false)) {
       LOG(ERROR) << "could not get the block id "
                  << block
                  << " because of "
@@ -627,7 +627,6 @@ void ZkClientDn::processDeleteQueue() {
 }
 
 ZkClientDn::~ZkClientDn() {
-  zk->close();
 }
 
 std::string ZkClientDn::build_datanode_id(DataNodeId data_node_id) {

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -359,7 +359,7 @@ bool ZkNnClient::get_block_size(const u_int64_t &block_id,
       auto child = children[i];
       BlockZNode block_data;
       std::vector<std::uint8_t> data(sizeof(block_data));
-      if (!zk->get(block_path + "/" + child, data, error_code)) {
+      if (!zk->get(block_path + "/" + child, data, error_code, false)) {
         LOG(ERROR) << "We could not read the block at " << block_path
                    << "/" << child;
         return false;

--- a/zookeeper/source/zk_nn_client.cc
+++ b/zookeeper/source/zk_nn_client.cc
@@ -336,12 +336,11 @@ bool ZkNnClient::get_block_size(const u_int64_t &block_id,
   if (!is_ec_block(block_id)) {
     BlockZNode block_data;
     std::vector<std::uint8_t> data(sizeof(block_data));
-    if (!zk->get(block_path, data, error_code)) {
+    if (!zk->get(block_path, data, error_code, false)) {
       LOG(ERROR) << "[get_block_size] We could not read "
           "the block at " << block_path;
       return false;
     }
-
     std::uint8_t *buffer = &data[0];
     memcpy(&block_data, &data[0], sizeof(block_data));
 
@@ -713,7 +712,7 @@ void ZkNnClient::read_file_znode(FileZNode &znode_data,
                                  const std::string &path) {
   int error_code;
   std::vector<std::uint8_t> data(sizeof(znode_data));
-  if (!zk->get(ZookeeperFilePath(path), data, error_code)) {
+  if (!zk->get(ZookeeperFilePath(path), data, error_code, false)) {
     LOG(ERROR) << "[read_file_znode] We could not read the file znode "
             "at " << path;
     return;  // don't bother reading the data
@@ -739,7 +738,7 @@ template <class T>
 void ZkNnClient::read_znode_data(T &znode_data, const std::string &path) {
   int error_code;
   std::vector<std::uint8_t> data(sizeof(znode_data));
-  if (!zk->get(path, data, error_code)) {
+  if (!zk->get(path, data, error_code, false)) {
     LOG(ERROR) << "[read_znode_data] We could not read znode data at " << path;
     return;  // don't bother reading the data
   }
@@ -814,7 +813,7 @@ bool ZkNnClient::set_owner(SetOwnerRequestProto &req,
   // Write the modified node back to Zookeeper
   zk->set(ZookeeperFilePath(path), zk_data, zk_error);
 
-  if (zk_error != ZK_ERRORS::OK) {
+  if (zk_error != ZOK) {
     LOG(ERROR) << "[set_owner] ZK reported error writing modified node "
             "back to disk";
     return false;
@@ -1236,9 +1235,9 @@ ZkNnClient::DeleteResponse ZkNnClient::destroy_helper(const std::string &path,
       auto child_path = util::concat_path(ZookeeperBlocksPath(path), child);
       child_path = child_path;
       ops.push_back(zk->build_delete_op(child_path));
-      std::vector<std::uint8_t> block_vec;
       std::uint64_t block;
-      if (!zk->get(child_path, block_vec, error_code, sizeof(block))) {
+      auto block_vec = std::vector<std::uint8_t>(sizeof(block));
+      if (!zk->get(child_path, block_vec, error_code, false)) {
         LOG(ERROR) << "[destroy_helper] failed block retrieval "
                 "in destroy helper";
         return DeleteResponse::FailedBlockRetrieval;
@@ -1323,9 +1322,9 @@ void ZkNnClient::complete(CompleteRequestProto& req,
 
     // TODO(2016): This loop could be two multi-ops instead
   for (auto file_block : file_blocks) {
-    auto data = std::vector<std::uint8_t>();
+    auto data = std::vector<std::uint8_t>(sizeof(uint64_t));
     if (!zk->get(ZookeeperBlocksPath(src) + "/" + file_block, data,
-                 error_code, sizeof(uint64_t))) {
+                 error_code, false)) {
       LOG(ERROR) << "[complete] Failed to get "
                  << ZookeeperBlocksPath(src)
                  << "/"
@@ -1336,11 +1335,10 @@ void ZkNnClient::complete(CompleteRequestProto& req,
       return;
     }
     uint64_t block_uuid = *reinterpret_cast<uint64_t *>(&data[0]);
-
-    auto block_data = std::vector<std::uint8_t>();
+    auto block_data = std::vector<std::uint8_t>(sizeof(uint64_t));
     std::string block_metadata_path = get_block_metadata_path(block_uuid);
     if (!zk->get(block_metadata_path,
-                 block_data, error_code, sizeof(uint64_t))) {
+                 block_data, error_code, false)) {
       LOG(ERROR) << "[complete] Failed to get "
                  << block_metadata_path
                  << " with error: "
@@ -1870,9 +1868,9 @@ void ZkNnClient::get_block_locations(const std::string &src,
     }
 
     // Retreive block size
-    auto data = std::vector<uint8_t>();
+    auto data = std::vector<uint8_t>(sizeof(uint64_t));
     if (!zk->get(zk_path + "/" + sorted_block, data,
-                 error_code, sizeof(uint64_t))) {
+                 error_code, false)) {
       LOG(ERROR) << "[get_block_locations] Failed to get "
       << zk_path << "/"
       << sorted_block
@@ -1887,7 +1885,7 @@ void ZkNnClient::get_block_locations(const std::string &src,
     BlockZNode block_data;
     std::vector<std::uint8_t> block_data_vec(sizeof(block_data));
     if (!zk->get(block_metadata_path, block_data_vec, error_code,
-                 sizeof(block_data))) {
+                 false)) {
       LOG(ERROR) << "[get_block_locations] Failed getting block size for "
       << block_metadata_path << " with error " << error_code;
     }
@@ -2086,10 +2084,9 @@ bool ZkNnClient::sort_by_xmits(const std::vector<std::string> &unsorted_dn_ids,
 
   for (auto datanode : unsorted_dn_ids) {
     std::string dn_stats_path = HEALTH_BACKSLASH + datanode + STATS;
-    std::vector<uint8_t> stats_payload;
-    stats_payload.resize(sizeof(DataNodePayload));
+    auto stats_payload = std::vector<uint8_t>(sizeof(DataNodePayload));
     if (!zk->get(dn_stats_path, stats_payload,
-           error_code, sizeof(DataNodePayload))) {
+           error_code, false)) {
       LOG(ERROR) << "[sort_by_xmits] Failed to get " << dn_stats_path;
       return false;
     }
@@ -2273,9 +2270,9 @@ void ZkNnClient::set_file_info(HdfsFileStatusProto *status,
     // Write the modified node back to Zookeeper
     zk->set(ZookeeperFilePath(path), zk_data, zk_error);
 
-
-  if (zk_error != ZK_ERRORS::OK) {
-    LOG(ERROR) << "ZK reported error writing modified node back to disk";
+  if (zk_error != ZOK) {
+    LOG(ERROR) << "[set_permission] ZK reported error writing modified "
+            "node back to disk";
     return false;
   }
 
@@ -2539,10 +2536,9 @@ bool ZkNnClient::find_datanode_for_block(std::vector<std::string> &datanodes,
 
         if (!exclude) {
           std::string dn_stats_path = HEALTH_BACKSLASH + datanode + STATS;
-          std::vector<uint8_t> stats_payload;
-          stats_payload.resize(sizeof(DataNodePayload));
+          auto stats_payload = std::vector<uint8_t>(sizeof(DataNodePayload));
           if (!zk->get(dn_stats_path, stats_payload,
-                 error_code, sizeof(DataNodePayload))) {
+                 error_code, false)) {
             LOG(ERROR) << "[find_datanode_for_block] Failed to get "
                        << dn_stats_path;
             return false;
@@ -2653,7 +2649,7 @@ bool ZkNnClient::rename_ops_for_file(const std::string &src,
   std::string dst_znode_leases = LeaseZookeeperPath(dst);
 
   // Get the payload from the old filesystem znode for the src
-  zk->get(src_znode, data, error_code);
+  zk->get(src_znode, data, error_code, true);
   if (error_code != ZOK) {
     LOG(ERROR) << "[rename_ops_for_file] Failed to get data from '"
                << src_znode
@@ -2666,7 +2662,7 @@ bool ZkNnClient::rename_ops_for_file(const std::string &src,
             << ": create " << dst_znode;
   ops.push_back(zk->build_create_op(dst_znode, data));
 
-    zk->get(src_znode_blocks, data, error_code);
+    zk->get(src_znode_blocks, data, error_code, true);
     if (error_code != ZOK) {
         LOG(ERROR) << "[rename_ops_for_file] Failed to get data from '"
                    << src_znode
@@ -2681,7 +2677,7 @@ bool ZkNnClient::rename_ops_for_file(const std::string &src,
 
   // Copy over the lease branch
   auto lease_data = std::vector<std::uint8_t>();
-  zk->get(src_znode_leases, lease_data, error_code);
+  zk->get(src_znode_leases, lease_data, error_code, true);
   if (error_code != ZOK) {
     LOG(ERROR) << "[rename_ops_for_file] Failed to get data from '"
     << src_znode_leases
@@ -2701,7 +2697,7 @@ bool ZkNnClient::rename_ops_for_file(const std::string &src,
   for (auto child : lease_children) {
     auto child_data = std::vector<std::uint8_t>();
 
-    zk->get(src_znode_leases + "/" + child, child_data, error_code);
+    zk->get(src_znode_leases + "/" + child, child_data, error_code, true);
     if (error_code != ZOK) {
       LOG(ERROR) << "[rename_ops_for_file] Failed to get data from '"
                  << child << "' when renaming.";
@@ -2738,7 +2734,7 @@ bool ZkNnClient::rename_ops_for_file(const std::string &src,
   for (auto child : children) {
     // Get child's data
     auto child_data = std::vector<std::uint8_t>();
-    zk->get(src_znode_blocks + "/" + child, child_data, error_code);
+    zk->get(src_znode_blocks + "/" + child, child_data, error_code, true);
     if (error_code != ZOK) {
       LOG(ERROR) << "Failed to get data from '" << child << "' when renaming.";
       return false;
@@ -2782,7 +2778,7 @@ bool ZkNnClient::rename_ops_for_dir(const std::string &src,
   std::string dst_znode = ZookeeperFilePath(dst);
 
   // Get the payload from the old filesystem znode for the src
-  zk->get(src_znode, data, error_code);
+  zk->get(src_znode, data, error_code, true);
   if (error_code != ZOK) {
     LOG(ERROR) << "[rename_ops_for_dir] Failed to get data from '"
            << src_znode
@@ -2883,7 +2879,7 @@ bool ZkNnClient::check_acks() {
                  + block_uuid;
 
     auto data = std::vector<std::uint8_t>();
-    if (!zk->get(block_path, data, error_code)) {
+    if (!zk->get(block_path, data, error_code, true)) {
       LOG(ERROR) << "[check_acks] Error getting payload at: " << block_path;
       auto undo_ack_op = zk->build_delete_op(block_path);
       ops.push_back(undo_ack_op);
@@ -3114,9 +3110,9 @@ bool ZkNnClient::buildDatanodeInfoProto(DatanodeInfoProto *dn_info,
   boost::split(split_address, data_node, boost::is_any_of(":"));
   assert(split_address.size() == 2);
 
-  auto data = std::vector<std::uint8_t>();
-  if (!zk->get(HEALTH_BACKSLASH + data_node + STATS, data,
-        error_code, sizeof(zkclient::DataNodePayload))) {
+  auto data = std::vector<std::uint8_t>(sizeof(zkclient::DataNodePayload));
+  if (zk->get(HEALTH_BACKSLASH + data_node + STATS, data,
+        error_code, false)) {
     LOG(ERROR) << "[buildDatanodeInfoProto] Getting data node stats "
             "failed with " << error_code;
   }


### PR DESCRIPTION
This patch improves ZKWrapper in various ways and contains no functionality changes to ZKWrapper. Following is a (somewhat comprehensive) list:

- Add robust and sane error handling to the initialization process in the constructor:
    - Wait for the connection to ZooKeeper to be fully established before issuing any request.
    - Place a hard limit on the number of retries to avoid infinite loop in the case where ZooKeeper is unavailable.
- Better resource reclamation.
- Implement sane automatic resizing of buffer when getting znode data.
- Avoid caching data on faulty operations.
- Use unique_ptr rather than shared_ptr or raw pointer wherever appropriate.
- Better printing of watch event types and states.
- Better handling of unknown error codes, watch event types and states.
- Remove redefined error codes.
- Replace plain literals with named constants.
- Narrow the scope of local variables wherever appropriate.
- Use auto wherever suitable.
- Reorder member declarations.
- Eliminate most of the TODO’s from 2016.
- Add TODO's for potential improvements to be done in the future.